### PR TITLE
Use mupdf for pdf extraction instead of jvm pdf extraction

### DIFF
--- a/colandr/api/resources/fulltext_uploads.py
+++ b/colandr/api/resources/fulltext_uploads.py
@@ -89,7 +89,7 @@ class FulltextUploadResource(Resource):
             elif ext == '.pdf':
                 extract_text_script = os.path.join(
                     current_app.config['COLANDR_APP_DIR'],
-                    'pdfestrian/bin/extractText.sh')
+                    'scripts/extractText.sh')
                 text_content = subprocess.check_output(
                     [extract_text_script, '--filename', filepath],
                     stderr=subprocess.STDOUT)

--- a/notebooks/nlp-tests.ipynb
+++ b/notebooks/nlp-tests.ipynb
@@ -42,6 +42,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -297,7 +298,7 @@
     "import subprocess\n",
     "\n",
     "result = subprocess.check_output(\n",
-    "    ['../pdfestrian/bin/extractText.sh', '-f', '/Users/burtondewilde/colandr/fulltexts/uploads/1.pdf'])\n",
+    "    ['../scripts/extractText.sh', '-f', '/Users/burtondewilde/colandr/fulltexts/uploads/1.pdf'])\n",
     "result[:100]"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "sqlalchemy>=1.2.0,<1.3.0",
   "textacy~=0.10.0",  # no higher until most_discriminating_terms replacement secured
   "webargs~=1.5",
-  "pymupdf>=1.22.3"
+  "pymupdf~=1.22.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "sqlalchemy>=1.2.0,<1.3.0",
   "textacy~=0.10.0",  # no higher until most_discriminating_terms replacement secured
   "webargs~=1.5",
+  "pymupdf>=1.22.3"
 ]
 
 [project.optional-dependencies]

--- a/scripts/extractText.sh
+++ b/scripts/extractText.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export APP_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )" 
+echo "APP_HOME: $APP_HOME"
+# This script is used to extract text from a PDF file.
+# It outputs the text to stdout.
+# It calls extract_pdf_text.py, directly passing the arguments to it.
+
+# The script is called as follows:
+# extractText.sh -f <input_file> --html
+python3 $APP_HOME/scripts/extract_pdf_text.py "$@"

--- a/scripts/extractText.sh
+++ b/scripts/extractText.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 export APP_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )" 
-echo "APP_HOME: $APP_HOME"
 # This script is used to extract text from a PDF file.
 # It outputs the text to stdout.
 # It calls extract_pdf_text.py, directly passing the arguments to it.

--- a/scripts/extract_pdf_text.py
+++ b/scripts/extract_pdf_text.py
@@ -6,7 +6,7 @@ def extract_pdf_text(pdf_path: str, output_type: str = "text" ):
     """ Extracts text from a PDF file and writes it to a text file. """
     with fitz.open(pdf_path) as doc:
         for page in doc: # iterate the document pages
-	        text = page.get_text(output_type).encode("utf8") # get plain text (is in UTF-8)
+	        text = page.get_text(output_type, sort=True).encode("utf8") # get plain text (is in UTF-8), sort = True ensure text returns is some "readable" order.
 	        sys.stdout.buffer.write(text) # write text of page
 	        sys.stdout.buffer.write(bytes((12,))) # write page delimiter (form feed 0x0C)
 

--- a/scripts/extract_pdf_text.py
+++ b/scripts/extract_pdf_text.py
@@ -1,0 +1,22 @@
+import fitz
+import sys
+import argparse
+
+def extract_pdf_text(pdf_path: str, output_type: str = "text" ):
+    """ Extracts text from a PDF file and writes it to a text file. """
+    with fitz.open(pdf_path) as doc:
+        for page in doc: # iterate the document pages
+	        text = page.get_text(output_type).encode("utf8") # get plain text (is in UTF-8)
+	        sys.stdout.buffer.write(text) # write text of page
+	        sys.stdout.buffer.write(bytes((12,))) # write page delimiter (form feed 0x0C)
+
+
+def main(): 
+    parser = argparse.ArgumentParser(description='Extract text from PDF file.', add_help=False)
+    parser.add_argument('-f', '--filename', type=str, required=True, help='Filename of pdf.')
+    parser.add_argument('-h', '--html', action='store_true', help='flag, if on will extract html string instead of plain text.')
+    args = parser.parse_args()
+    extract_pdf_text(args.filename, "html" if args.html else "text")
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Moved the pdf extraction to python. Not sure we want to keep it in `scripts` folder though. We can also directly call the pdf extraction code in the `fulltext_uploads.py`, but I figured we can start here so that I start deleting things from scala. 

Closes #46 