### PR TITLE
Hack on config, testing

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,9 +25,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8",]
-        os: [ubuntu-latest]  # macos-latest
+        # TODO: also run on macos-latest pending docker/colima issue
+        os: [ubuntu-latest]
 
     services:
+      # NOTE: these containers should match those in app's docker compose file
       colandr_db:
         image: "postgres:10"
         env:
@@ -41,6 +43,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      colandr_broker:
+        image: "redis:6.0"
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,8 +15,7 @@ env:
   COLANDR_APP_DIR: "/path/to/colandr"
   COLANDR_MAIL_USERNAME: "colandr_mail_username"
   COLANDR_MAIL_PASSWORD: "colandr_mail_password"
-  COLANDR_DATABASE_URI: "colandr_database_uri"
-  DEV_COLANDR_DATABASE_URI: "dev_colandr_database_uri"
+  COLANDR_DATABASE_URI: "postgresql://colandr_app:password@colandr_db:5432/colandr"
 
 jobs:
 
@@ -27,6 +26,22 @@ jobs:
       matrix:
         python-version: ["3.8",]
         os: [macos-latest, ubuntu-latest]
+
+    services:
+      colandr_db:
+        image: "postgres:10"
+        env:
+          POSTGRES_USER: "colandr_app"
+          POSTGRES_PASSWORD: "password"
+          POSTGRES_DB: "colandr"
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready -U colandr_app -d colandr
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -43,9 +58,9 @@ jobs:
       run: |
         python3 -m textacy download lang_identifier
         python3 -m spacy download en_core_web_md
-  #   - name: Test with pytest
-  #     run: |
-  #       python -m pytest tests --verbose
+    - name: Test with pytest
+      run: |
+        python -m pytest tests --verbose
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,7 +37,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready -U colandr_app -d colandr
+          --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ env:
   COLANDR_APP_DIR: "/path/to/colandr"
   COLANDR_MAIL_USERNAME: "colandr_mail_username"
   COLANDR_MAIL_PASSWORD: "colandr_mail_password"
-  COLANDR_DATABASE_URI: "postgresql://colandr_app:password@colandr_db:5432/colandr"
+  COLANDR_DATABASE_URI: "postgresql://colandr_app:password@localhost:5432/colandr"
 
 jobs:
 
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8",]
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]  # macos-latest
 
     services:
       colandr_db:

--- a/colandr/api/__init__.py
+++ b/colandr/api/__init__.py
@@ -18,6 +18,7 @@ api_ = Api(
 
 from .auth import ns as ns_auth
 from .errors import ns as errors_ns
+from .health import ns as ns_health
 from .resources.citation_imports import ns as citation_imports_ns
 from .resources.citation_screenings import ns as citation_screenings_ns
 from .resources.citations import ns as citations_ns
@@ -41,6 +42,7 @@ flask_praetorian.PraetorianError.register_error_handler_with_flask_restx(api_)
 
 api_.add_namespace(ns_auth)
 api_.add_namespace(errors_ns)
+api_.add_namespace(ns_health)
 api_.add_namespace(swagger_ns)
 api_.add_namespace(users_ns)
 api_.add_namespace(reviews_ns)

--- a/colandr/api/health.py
+++ b/colandr/api/health.py
@@ -1,0 +1,19 @@
+from flask_restx import Namespace, Resource
+
+from ..extensions import db
+
+
+ns = Namespace(
+    "health",
+    path="/health",
+    description="check health of api and related services in a minimal way",
+)
+
+
+@ns.route("", doc={"produces": ["application/json"]})
+class HealthResource(Resource):
+    @ns.doc(responses={200: "api is healthy"})
+    def get(self):
+        # TODO: redis.ping() ?
+        db.engine.execute("SELECT 1")
+        return "OK"

--- a/colandr/api/resources/review_teams.py
+++ b/colandr/api/resources/review_teams.py
@@ -161,6 +161,7 @@ class ReviewTeamResource(Resource):
                 review_users.append(user)
             else:
                 return forbidden_error("{} is already on this review".format(user))
+        # TODO: update this to use flask-praetorian tokens + emailing
         # user is being *invited*, so send an invitation email
         elif action == "invite":
             serializer = URLSafeSerializer(current_app.config["SECRET_KEY"])

--- a/colandr/api/resources/studies.py
+++ b/colandr/api/resources/studies.py
@@ -3,12 +3,12 @@ import random
 from operator import itemgetter
 
 import flask_praetorian
+import joblib
 import numpy as np
 from flask import current_app, g
 from flask_restx import Namespace, Resource
 from marshmallow import fields as ma_fields
 from marshmallow.validate import Length, OneOf, Range
-from sklearn.externals import joblib
 from sqlalchemy import asc, desc, text
 from sqlalchemy.sql import operators
 from webargs.fields import DelimitedList

--- a/colandr/app.py
+++ b/colandr/app.py
@@ -26,11 +26,6 @@ def configure_logging(app: flask.Flask):
     """Configure logging on ``app`` ."""
     if app.logger.handlers:
         app.logger.removeHandler(flask.logging.default_handler)
-    # app.logger.addHandler(
-    #     get_rotating_file_handler(
-    #         os.path.join(app.config["LOGS_DIR"], app.config["LOG_FILENAME"])
-    #     )
-    # )
     app.logger.addHandler(get_console_handler())
     app.logger.addFilter(logging.Filter("colandr"))
     # app.logger.propagate = False

--- a/colandr/app.py
+++ b/colandr/app.py
@@ -13,7 +13,6 @@ def create_app(config_name="dev"):
     app = flask.Flask("colandr")
     config = configs[config_name]()
     app.config.from_object(config)
-    config.init_app(app)
 
     configure_logging(app)
     register_extensions(app)

--- a/colandr/app.py
+++ b/colandr/app.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import flask
 import flask.logging
@@ -6,7 +7,6 @@ import flask.logging
 from colandr import cli, errors, extensions, models
 from colandr.api import api_
 from colandr.config import configs
-from colandr.lib.utils import get_console_handler
 
 
 def create_app(config_name="dev"):
@@ -26,9 +26,18 @@ def configure_logging(app: flask.Flask):
     """Configure logging on ``app`` ."""
     if app.logger.handlers:
         app.logger.removeHandler(flask.logging.default_handler)
-    app.logger.addHandler(get_console_handler())
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(module)s.%(funcName)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    handler.setLevel(app.config["LOG_LEVEL"])
+    app.logger.addHandler(handler)
+    # TODO: do we *want* to filter to just colandr's logging, or others' (deps') too?
     app.logger.addFilter(logging.Filter("colandr"))
-    # app.logger.propagate = False
 
 
 def register_extensions(app: flask.Flask):

--- a/colandr/app.py
+++ b/colandr/app.py
@@ -1,6 +1,7 @@
 import logging
 
-from flask import Flask
+import flask
+import flask.logging
 
 from colandr import cli, errors, extensions, models
 from colandr.api import api_
@@ -9,7 +10,7 @@ from colandr.lib.utils import get_console_handler
 
 
 def create_app(config_name="dev"):
-    app = Flask("colandr")
+    app = flask.Flask("colandr")
     config = configs[config_name]()
     app.config.from_object(config)
     config.init_app(app)
@@ -22,11 +23,13 @@ def create_app(config_name="dev"):
     return app
 
 
-def configure_logging(app):
+def configure_logging(app: flask.Flask):
     """Configure logging on ``app`` ."""
+    if app.logger.handlers:
+        app.logger.removeHandler(flask.logging.default_handler)
     # app.logger.addHandler(
     #     get_rotating_file_handler(
-    #         os.path.join(app.config.LOGS_DIR, app.config.LOG_FILENAME)
+    #         os.path.join(app.config["LOGS_DIR"], app.config["LOG_FILENAME"])
     #     )
     # )
     app.logger.addHandler(get_console_handler())
@@ -34,7 +37,7 @@ def configure_logging(app):
     # app.logger.propagate = False
 
 
-def register_extensions(app):
+def register_extensions(app: flask.Flask):
     """Register flask extensions on ``app`` ."""
     extensions.cache.init_app(app)
     with app.app_context():

--- a/colandr/app.py
+++ b/colandr/app.py
@@ -9,7 +9,7 @@ from colandr.api import api_
 from colandr.config import configs
 
 
-def create_app(config_name="dev"):
+def create_app(config_name: str = "dev") -> flask.Flask:
     app = flask.Flask("colandr")
     config = configs[config_name]()
     app.config.from_object(config)
@@ -22,7 +22,7 @@ def create_app(config_name="dev"):
     return app
 
 
-def configure_logging(app: flask.Flask):
+def configure_logging(app: flask.Flask) -> None:
     """Configure logging on ``app`` ."""
     if app.logger.handlers:
         app.logger.removeHandler(flask.logging.default_handler)
@@ -40,7 +40,7 @@ def configure_logging(app: flask.Flask):
     app.logger.addFilter(logging.Filter("colandr"))
 
 
-def register_extensions(app: flask.Flask):
+def register_extensions(app: flask.Flask) -> None:
     """Register flask extensions on ``app`` ."""
     extensions.cache.init_app(app)
     with app.app_context():

--- a/colandr/config.py
+++ b/colandr/config.py
@@ -13,12 +13,8 @@ class Config:
     SECRET_KEY = os.environ["COLANDR_SECRET_KEY"]
     MAX_CONTENT_LENGTH = 40 * 1024 * 1024  # 40MB file upload limit
 
-    PASSWORD_SALT = os.environ.get("COLANDR_PASSWORD_SALT")
-    BCRYPT_LOG_ROUNDS = 12
-    SSL_DISABLE = False
-    LOGGER_NAME = "colandr"
-    JSON_AS_ASCII = False
-    CONFIRM_TOKEN_EXPIRATION = 3600
+    PASSWORD_SALT = os.environ.get("COLANDR_PASSWORD_SALT")  # TODO: remove this
+    # SSL_DISABLE = False
     APP_URL_DOMAIN = "http://localhost:5001/api"
 
     # celery+redis config
@@ -43,8 +39,6 @@ class Config:
 
     # files-on-disk config
     COLANDR_APP_DIR = os.environ.get("COLANDR_APP_DIR", "/tmp")
-    LOGS_DIR = os.path.join(COLANDR_APP_DIR, "colandr_data", "logs")
-    LOG_FILENAME = "colandr.log"
     DEDUPE_MODELS_DIR = os.path.join(COLANDR_APP_DIR, "colandr_data", "dedupe")
     RANKING_MODELS_DIR = os.path.join(COLANDR_APP_DIR, "colandr_data", "ranking_models")
     CITATIONS_DIR = os.path.join(COLANDR_APP_DIR, "colandr_data", "citations")
@@ -77,14 +71,10 @@ class ProductionConfig(Config):
 
 class DevelopmentConfig(Config):
     FLASK_ENV = "development"
-    LOGGER_NAME = "dev-colandr"
-    LOG_FILENAME = "dev-colandr.log"
 
 
 class TestingConfig(Config):
     TESTING = True
-    LOGGER_NAME = "test-colandr"
-    LOG_FILENAME = "test-colandr.log"
     SQLALCHEMY_ECHO = True
 
 

--- a/colandr/config.py
+++ b/colandr/config.py
@@ -31,6 +31,12 @@ class Config:
     CELERY_RESULT_SERIALIZER = "json"
     CELERYD_LOG_COLOR = False
 
+    # cache config
+    CACHE_TYPE = "SimpleCache"
+    # TODO: figure out if/how we want to use redis for caching
+    # CACHE_TYPE = "RedisCache",
+    # CACHE_REDIS_HOST = os.environ.get("COLANDR_REDIS_HOST", "localhost")
+
     # sql db config
     SQLALCHEMY_DATABASE_URI = os.environ["COLANDR_DATABASE_URI"]
     SQLALCHEMY_ECHO = False

--- a/colandr/config.py
+++ b/colandr/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from dotenv import load_dotenv
@@ -16,6 +17,7 @@ class Config:
     PASSWORD_SALT = os.environ.get("COLANDR_PASSWORD_SALT")  # TODO: remove this
     # SSL_DISABLE = False
     APP_URL_DOMAIN = "http://localhost:5001/api"
+    LOG_LEVEL = os.getenv("COLANDR_LOG_LEVEL", logging.INFO)
 
     # celery+redis config
     CELERY_BROKER_URL = os.environ.get(

--- a/colandr/config.py
+++ b/colandr/config.py
@@ -11,6 +11,8 @@ load_dotenv(os.path.join(basedir, ".env"))
 class Config:
     TESTING = False
     SECRET_KEY = os.environ["COLANDR_SECRET_KEY"]
+    MAX_CONTENT_LENGTH = 40 * 1024 * 1024  # 40MB file upload limit
+
     PASSWORD_SALT = os.environ.get("COLANDR_PASSWORD_SALT")
     BCRYPT_LOG_ROUNDS = 12
     SSL_DISABLE = False
@@ -48,7 +50,6 @@ class Config:
     CITATIONS_DIR = os.path.join(COLANDR_APP_DIR, "colandr_data", "citations")
     FULLTEXT_UPLOADS_DIR = os.path.join(COLANDR_APP_DIR, "colandr_data", "fulltexts")
     ALLOWED_FULLTEXT_UPLOAD_EXTENSIONS = {".txt", ".pdf"}
-    MAX_CONTENT_LENGTH = 40 * 1024 * 1024  # 40MB file upload limit
 
     # email server config
     MAIL_SERVER = os.environ.get("COLANDR_MAIL_SERVER")
@@ -68,10 +69,6 @@ class Config:
     MAIL_DEFAULT_SENDER = f"colandr <{MAIL_USERNAME}>"
     MAIL_SUBJECT_PREFIX = "[colandr]"
     MAIL_ADMINS = ["burtdewilde@gmail.com"]
-
-    @staticmethod
-    def init_app(app):
-        pass
 
 
 class ProductionConfig(Config):

--- a/colandr/errors.py
+++ b/colandr/errors.py
@@ -15,7 +15,7 @@ def handle_error(error):
 
 @bp.app_errorhandler(SQLAlchemyError)
 def handle_sqlalchemy_error(error):
-    current_app.logger.error("db unable to handle request! rolling back...")
+    current_app.logger.error("unexpected db error: %s\nrolling back ... %s", error)
     db.session.rollback()
     db.session.remove()
     return (jsonify({"errors": str(error)}), 500)

--- a/colandr/extensions.py
+++ b/colandr/extensions.py
@@ -10,8 +10,10 @@ import flask_sqlalchemy
 
 cache = flask_caching.Cache(
     config={
-        "CACHE_TYPE": "RedisCache",
-        "CACHE_REDIS_HOST": os.environ.get("COLANDR_REDIS_HOST", "localhost"),
+        # TODO: figure out what we want to do here re: redis, caching *at all*
+        "CACHE_TYPE": "SimpleCache",
+        # "CACHE_TYPE": "RedisCache",
+        # "CACHE_REDIS_HOST": os.environ.get("COLANDR_REDIS_HOST", "localhost"),
     },
 )
 db = flask_sqlalchemy.SQLAlchemy()

--- a/colandr/extensions.py
+++ b/colandr/extensions.py
@@ -8,14 +8,7 @@ import flask_praetorian
 import flask_sqlalchemy
 
 
-cache = flask_caching.Cache(
-    config={
-        # TODO: figure out what we want to do here re: redis, caching *at all*
-        "CACHE_TYPE": "SimpleCache",
-        # "CACHE_TYPE": "RedisCache",
-        # "CACHE_REDIS_HOST": os.environ.get("COLANDR_REDIS_HOST", "localhost"),
-    },
-)
+cache = flask_caching.Cache()
 db = flask_sqlalchemy.SQLAlchemy()
 guard = flask_praetorian.Praetorian()
 mail = flask_mail.Mail()

--- a/colandr/lib/parsers/bibtex.py
+++ b/colandr/lib/parsers/bibtex.py
@@ -1,18 +1,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import io
+import logging
 import re
 
 import bibtexparser
 from bibtexparser.bparser import BibTexParser
 from bibtexparser.customization import convert_to_unicode, getnames
 
-from .. import utils
-
 
 # TODO: confirm that 'references' sanitization is correct
 
-logger = utils.get_console_logger(__name__)
+logger = logging.getLogger(__name__)
 
 WHITESPACE_RE = re.compile(r"\s+")
 _MONTH_MAP = {

--- a/colandr/lib/parsers/ris.py
+++ b/colandr/lib/parsers/ris.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import io
+import logging
 import re
 
 from dateutil.parser import parse as parse_date
 
-from .. import utils
 
-
-logger = utils.get_console_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 KEY_MAP = {

--- a/colandr/lib/utils.py
+++ b/colandr/lib/utils.py
@@ -1,21 +1,9 @@
 import io
 import logging
 import logging.handlers
-import sys
 
 import dedupe
 from sqlalchemy.sql import text
-
-
-def get_console_handler(level=logging.WARNING):
-    _handler = logging.StreamHandler(stream=sys.stdout)
-    _formatter = logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(module)s.%(funcName)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    _handler.setFormatter(_formatter)
-    _handler.setLevel(level)
-    return _handler
 
 
 def execute_raw_sql_query(query, bindings=None, no_logging=True):

--- a/colandr/lib/utils.py
+++ b/colandr/lib/utils.py
@@ -1,24 +1,10 @@
 import io
 import logging
 import logging.handlers
-import os
 import sys
 
 import dedupe
 from sqlalchemy.sql import text
-
-
-def get_rotating_file_handler(filepath, level=logging.INFO):
-    _handler = logging.handlers.RotatingFileHandler(
-        filepath, maxBytes=1000000, backupCount=10, delay=False
-    )
-    _formatter = logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(name)s - %(module)s.%(funcName)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    _handler.setFormatter(_formatter)
-    _handler.setLevel(level)
-    return _handler
 
 
 def get_console_handler(level=logging.WARNING):
@@ -30,55 +16,6 @@ def get_console_handler(level=logging.WARNING):
     _handler.setFormatter(_formatter)
     _handler.setLevel(level)
     return _handler
-
-
-def get_console_logger(name, level="info"):
-    logger = logging.getLogger(name)
-    if level == "debug":
-        logger.setLevel(logging.DEBUG)
-    elif level == "info":
-        logger.setLevel(logging.INFO)
-    elif level == "warning":
-        logger.setLevel(logging.WARNING)
-    else:
-        logger.setLevel(logging.ERROR)
-    _handler = logging.StreamHandler()
-    _formatter = logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    _handler.setFormatter(_formatter)
-    logger.addHandler(_handler)
-    logging.captureWarnings(True)
-    return logger
-
-
-def get_rotating_file_logger(name, filepath, level="info"):
-    head, _ = os.path.split(filepath)
-    os.makedirs(head, exist_ok=True)
-    logger = logging.getLogger(name)
-    if level == "debug":
-        logger.setLevel(logging.DEBUG)
-    elif level == "info":
-        logger.setLevel(logging.INFO)
-    elif level == "warning":
-        logger.setLevel(logging.WARNING)
-    else:
-        logger.setLevel(logging.ERROR)
-    _handler = logging.handlers.RotatingFileHandler(
-        filepath, maxBytes=1000000, backupCount=10, delay=False
-    )
-    _formatter = logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    _handler.setFormatter(_formatter)
-    logger.addHandler(_handler)
-    _filter = logging.Filter("colandr")
-    logger.addFilter(_filter)
-    logger.propagate = False
-    logging.captureWarnings(True)
-    return logger
 
 
 def execute_raw_sql_query(query, bindings=None, no_logging=True):

--- a/colandr/lib/utils.py
+++ b/colandr/lib/utils.py
@@ -2,6 +2,7 @@ import io
 import logging
 import logging.handlers
 import os
+import sys
 
 import dedupe
 from sqlalchemy.sql import text
@@ -21,7 +22,7 @@ def get_rotating_file_handler(filepath, level=logging.INFO):
 
 
 def get_console_handler(level=logging.WARNING):
-    _handler = logging.StreamHandler()
+    _handler = logging.StreamHandler(stream=sys.stdout)
     _formatter = logging.Formatter(
         "%(asctime)s - %(levelname)s - %(module)s.%(funcName)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",

--- a/colandr/models.py
+++ b/colandr/models.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 
 from sqlalchemy import ForeignKey, event, false, text
 from sqlalchemy.dialects import postgresql
@@ -6,10 +7,9 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from .api.utils import assign_status, get_boolean_search_query
 from .extensions import db
-from .lib.utils import get_console_logger
 
 
-logger = get_console_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # association table for users-reviews many-to-many relationship

--- a/colandr/tasks.py
+++ b/colandr/tasks.py
@@ -25,7 +25,7 @@ from sqlalchemy.sql import case, delete, exists, select, text, update
 from .api.schemas import ReviewPlanSuggestedKeyterms
 from .extensions import cache, mail
 from .lib.constants import CITATION_RANKING_MODEL_FNAME
-from .lib.utils import get_console_logger, load_dedupe_model, make_record_immutable
+from .lib.utils import load_dedupe_model, make_record_immutable
 from .models import (
     Citation,
     Dedupe,
@@ -50,7 +50,6 @@ REDIS_CONN = redis.Redis(
 REDIS_LOCK_TIMEOUT = 60 * 3  # seconds
 
 logger = get_task_logger(__name__)
-console_logger = get_console_logger(__name__)
 
 
 @shared_task

--- a/colandr/tasks.py
+++ b/colandr/tasks.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import case, delete, exists, select, text, update
 
 from .api.schemas import ReviewPlanSuggestedKeyterms
-from .extensions import cache, mail
+from .extensions import cache, db, mail
 from .lib.constants import CITATION_RANKING_MODEL_FNAME
 from .lib.utils import load_dedupe_model, make_record_immutable
 from .models import (
@@ -38,14 +38,12 @@ from .models import (
     ReviewPlan,
     Study,
     User,
-    db,
 )
 
 
-# TODO: figure out if we can use current celery app's redis connection info
-REDIS_CONN = redis.Redis(
-    host=os.environ.get("COLANDR_REDIS_HOST", "localhost"),
-    port=int(os.environ.get("COLANDR_REDIS_PORT", "6379")),
+# TODO: figure out if we can use current celery app's redis connection info?
+REDIS_CONN = redis.Redis.from_url(
+    os.getenv("COLANDR_CELERY_BROKER_URL", "redis://localhost:6379/0")
 )
 REDIS_LOCK_TIMEOUT = 60 * 3  # seconds
 

--- a/colandr/tasks.py
+++ b/colandr/tasks.py
@@ -42,9 +42,9 @@ from .models import (
 
 
 # TODO: figure out if we can use current celery app's redis connection info?
-REDIS_CONN = redis.Redis.from_url(
-    os.getenv("COLANDR_CELERY_BROKER_URL", "redis://localhost:6379/0")
-)
+# REDIS_CONN = redis.Redis.from_url(
+#     os.getenv("COLANDR_CELERY_BROKER_URL", "redis://localhost:6379/0")
+# )
 REDIS_LOCK_TIMEOUT = 60 * 3  # seconds
 
 logger = get_task_logger(__name__)
@@ -88,6 +88,8 @@ def _get_candidate_dupes(results):
 @shared_task
 def deduplicate_citations(review_id):
     lock_id = f"deduplicate_ciations__review-{review_id}"
+    REDIS_CONN = current_celery_app.backend.client
+    assert isinstance(REDIS_CONN, redis.client.Redis)
     lock = REDIS_CONN.lock(
         lock_id, timeout=REDIS_LOCK_TIMEOUT, sleep=1.0, blocking=True
     )

--- a/colandr/tasks.py
+++ b/colandr/tasks.py
@@ -3,6 +3,7 @@ import os
 from time import sleep
 
 import arrow
+import joblib
 import numpy as np
 import redis
 import textacy
@@ -14,7 +15,6 @@ from celery import shared_task
 from celery.utils.log import get_task_logger
 from flask import current_app
 from flask_mail import Message
-from sklearn.externals import joblib
 from sklearn.linear_model import SGDClassifier
 from sqlalchemy import create_engine, func
 from sqlalchemy import types as sqltypes

--- a/compose.yml
+++ b/compose.yml
@@ -4,10 +4,8 @@ services:
   db:
     container_name: colandr-db
     image: "postgres:10"
-    restart: always
+    restart: unless-stopped
     stop_grace_period: 5s
-    networks:
-      - colandr-back
     volumes:
       - db-data:/var/lib/postgresql/data
     ports:
@@ -34,15 +32,11 @@ services:
       - MP_SMTP_AUTH_ALLOW_INSECURE=1
       - MP_VERBOSE=1
       - MP_MAX_MESSAGES=100
-    networks:
-      - colandr-back
   broker:
     container_name: colandr-broker
     image: "redis:6.0"
-    restart: always
+    restart: unless-stopped
     stop_grace_period: 5s
-    networks:
-      - colandr-back
     volumes:
       - broker-data:/data
     ports:
@@ -53,12 +47,9 @@ services:
       context: "."
       dockerfile: Dockerfile
     depends_on:
-      db:
-        condition: service_healthy
-      broker:
-        condition: service_started
-      worker:
-        condition: service_started
+      - db
+      - broker
+      - worker
     stop_signal: SIGINT
     healthcheck:
       test: "curl localhost:5000/api/health"
@@ -77,8 +68,6 @@ services:
       - COLANDR_MAIL_PORT=1025
       - COLANDR_MAIL_USE_TLS=0
       - COLANDR_MAIL_USE_SSL=0
-    networks:
-      - colandr-back
     volumes:
       - .:/app
     ports:
@@ -100,12 +89,11 @@ services:
       - COLANDR_CELERY_BROKER_URL=redis://colandr-broker:6379/0
       - COLANDR_CELERY_RESULT_BACKEND=redis://colandr-broker:6379/0
       - COLANDR_REDIS_HOST=colandr-broker
-    networks:
-      - colandr-back
     command: "celery worker --app=celery_worker.celery --loglevel=info"
 
 networks:
-  colandr-back: {}
+  default:
+    name: "colandr-back"
 
 volumes:
   db-data: {}

--- a/compose.yml
+++ b/compose.yml
@@ -18,8 +18,8 @@ services:
       - PGDATA=/var/lib/postgresql/data
     healthcheck:
       test: "pg_isready -U ${COLANDR_DB_USER} -d ${COLANDR_DB_NAME}"
-      interval: 5s
-      timeout: 3s
+      interval: 10s
+      timeout: 5s
       retries: 5
   email:
     container_name: colandr-email
@@ -41,6 +41,11 @@ services:
       - broker-data:/data
     ports:
       - "6379:6379"
+    healthcheck:
+      test: "redis-cli ping"
+      interval: 10s
+      timeout: 5s
+      retries: 5
   api:
     container_name: colandr-api
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -60,6 +60,12 @@ services:
       worker:
         condition: service_started
     stop_signal: SIGINT
+    healthcheck:
+      test: "curl localhost:5000/api/health"
+      interval: "10s"
+      timeout: "3s"
+      start_period: "5s"
+      retries: 3
     env_file: ".env"
     environment:
       - FLASK_APP=colandr.app:create_app()

--- a/compose.yml
+++ b/compose.yml
@@ -77,7 +77,7 @@ services:
       - .:/app
     ports:
       - 5001:5000
-    command: "flask run --host 0.0.0.0 --port 5000"
+    command: "flask run --host 0.0.0.0 --port 5000 --debug"
   worker:
     container_name: colandr-worker
     build:

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,10 +1,12 @@
 import multiprocessing
+import os
 
 
-bind = "0.0.0.0:5000"
+bind = f"0.0.0.0:{os.environ.get('PORT', '5000')}"
 workers = multiprocessing.cpu_count()
 worker_class = "sync"
 timeout = 30
 reload = False
 pidfile = "./colandr.pid"
 daemon = False  # in prod, should proably be True
+accesslog = "-"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "gunicorn==19.6.0",  # TODO: upgrade this
   "itsdangerous~=2.0",
   "jinja2~=3.0",
+  "joblib~=1.0",
   "markupsafe~=2.0",
   "marshmallow>=2.10.3,<3.0.0",  # TODO: upgrade this to 3.0.0, see migration guide
   "numpy>=1.9,<1.20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "bibtexparser~=1.2.0",
   "celery~=4.0",
   "click~=8.0",
-  "dedupe~=1.4.14",
+  "dedupe~=1.4.14",  # TODO: upgrade this once good process for retraining model in place
   "flask~=2.2.0",
   "flask-caching~=2.0.0",
   "flask_mail>=0.9.1",  # TODO: this package is dead, we should replace it
@@ -30,11 +30,11 @@ dependencies = [
   "flask_sqlalchemy~=3.0.0",
   "flask-restx~=1.1.0",
   "ftfy~=5.0",
-  "gunicorn==19.6.0",
+  "gunicorn==19.6.0",  # TODO: upgrade this
   "itsdangerous~=2.0",
   "jinja2~=3.0",
   "markupsafe~=2.0",
-  "marshmallow>=2.10.3,<3.0.0",
+  "marshmallow>=2.10.3,<3.0.0",  # TODO: upgrade this to 3.0.0, see migration guide
   "numpy>=1.9,<1.20",
   "psycopg2-binary~=2.9.0",
   "pymupdf~=1.22.0",
@@ -45,7 +45,7 @@ dependencies = [
   "scikit-learn>=0.21.0,<0.23.0",  # doesn't build for PY >= 3.9
   "sqlalchemy~=1.4",
   "textacy~=0.10.0",  # no higher until most_discriminating_terms replacement secured
-  "webargs~=1.5",
+  "webargs~=1.5",  # TODO: upgrade this to 2.0 at same time as marshmallow to 3.0.0
 ]
 
 [project.optional-dependencies]

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -16,6 +16,7 @@ ftfy~=5.0
 gunicorn==19.6.0
 itsdangerous~=2.0
 jinja2~=3.0
+joblib~=1.0
 markupsafe~=2.0
 marshmallow>=2.10.3,<3.0.0
 numpy>=1.9,<1.20

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,5 @@
+class TestHealthResource:
+    def test_get(self, client):
+        url = "/api/health"
+        response = client.get(url)
+        assert response.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ def app():
     """Create and configure a new app instance, once per test session."""
     # create the app with common test config
     app = create_app("test")
+    # TODO: don't use a globally applied app context as here, only scope minimally
     with app.app_context():
         yield app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,19 @@ from colandr import extensions, models
 from colandr.app import create_app
 
 
+# TODO: consider hacking on a solution that doesn't require a running psql db
+# for example, this almost but didn't quite work
+# import pytest_postgresql.factories
+# psql_proc = pytest_postgresql.factories.postgresql_proc(
+#     host="localhost",
+#     port=5432,
+#     user="colandr_app",
+#     password="PASSWORD",
+#     dbname="colandr",
+# )
+# psql_db = pytest_postgresql.factories.postgresql("psql_proc", dbname="colandr")
+
+
 @pytest.fixture(scope="session")
 def seed_data():
     path = pathlib.Path(__file__).parent / "fixtures" / "seed_data.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import pathlib
 import pytest
 from flask import g
 
-# from colandr.extensions import db as _db, guard
 from colandr import extensions, models
 from colandr.app import create_app
 


### PR DESCRIPTION
### changes

- adds psql, redis services to CI job and actually runs tests
- slims and consolidates application+extensions configuration
- streamlines app logging setup and standardizes all loggers in modules
- replaces stand-alone, global redis connection with hidden, re-used conn for use in setting task locks; lets us use (non-task) app functionality without a running redis server, and is automatically the same server used by celery
- adds a health check api endpoint w/ unit test, as well as health check cmds for docker compose services
- adds and imports joblib package dep, to avoid deprecation warning from sklearn vendorized joblib