### PR TITLE
Extend unit tests (pt6)

### DIFF
--- a/colandr/api/resources/fulltexts.py
+++ b/colandr/api/resources/fulltexts.py
@@ -11,7 +11,6 @@ from ...models import Fulltext, db
 from ..errors import forbidden_error, not_found_error
 from ..schemas import FulltextSchema
 
-
 ns = Namespace("fulltexts", path="/fulltexts", description="get and delete fulltexts")
 
 
@@ -99,7 +98,11 @@ class FulltextResource(Resource):
         fulltext = db.session.query(Fulltext).get(id)
         if not fulltext:
             return not_found_error("<Fulltext(id={})> not found".format(id))
-        if fulltext.review.users.filter_by(id=current_user.id).one_or_none() is None:
+        if (
+            current_user.is_admin is False
+            and fulltext.review.users.filter_by(id=current_user.id).one_or_none()
+            is None
+        ):
             return forbidden_error(
                 "{} forbidden to delete this fulltext".format(current_user)
             )

--- a/colandr/api/resources/fulltexts.py
+++ b/colandr/api/resources/fulltexts.py
@@ -11,6 +11,7 @@ from ...models import Fulltext, db
 from ..errors import forbidden_error, not_found_error
 from ..schemas import FulltextSchema
 
+
 ns = Namespace("fulltexts", path="/fulltexts", description="get and delete fulltexts")
 
 

--- a/colandr/models.py
+++ b/colandr/models.py
@@ -1141,6 +1141,11 @@ def update_fulltext_status(mapper, connection, target):
     fulltext_id = target.fulltext_id
     review_id = target.review_id
     fulltext = target.fulltext
+    # TODO(burton): you added this so that conftest populate_db func would work
+    # for reasons unknown, the target here didn't have a loaded fulltext object
+    # but this is _probably_ a bad thing, and you should find a way to fix it
+    if fulltext is None:
+        fulltext = Fulltext.query.where(Fulltext.id == fulltext_id).one_or_none()
     # get the current (soon to be *old*) citation_status of the study
     with connection.begin():
         old_status = connection.execute(

--- a/tests/api/test_fulltext_screenings.py
+++ b/tests/api/test_fulltext_screenings.py
@@ -1,0 +1,118 @@
+import flask
+import pytest
+
+
+class TestFulltextScreeningsResource:
+    @pytest.mark.parametrize(
+        ["id_", "params", "status_code", "num_exp"],
+        [
+            (1, None, 200, 2),
+            (2, None, 200, 1),
+            (1, {"fields": "id,review_id"}, 200, 2),
+            (1, {"fields": "fulltext_id,status"}, 200, 2),
+            (999, None, 404, 0),
+        ],
+    )
+    def test_get(
+        self, id_, params, status_code, num_exp, app, client, admin_headers, seed_data
+    ):
+        with app.test_request_context():
+            url = flask.url_for(
+                "fulltext_screenings_fulltext_screenings_resource",
+                id=id_,
+                **(params or {}),
+            )
+        response = client.get(url, headers=admin_headers)
+        assert response.status_code == status_code
+        if 200 <= status_code < 300:
+            records = response.json
+            fields = None if params is None else params["fields"].split(",")
+            assert isinstance(records, list) and len(records) == num_exp
+            for record in records:
+                if "fulltext_id" in record:
+                    assert record["fulltext_id"] == id_
+                if fields:
+                    assert sorted(record.keys()) == sorted(fields)
+
+    @pytest.mark.parametrize(
+        ["id_", "data", "status_code"],
+        [
+            (2, {"user_id": 2, "status": "included"}, 200),
+            (
+                1,
+                {
+                    "user_id": 3,
+                    "status": "excluded",
+                    "exclude_reasons": ["REASON3"],
+                },
+                200,
+            ),
+            (999, {"status": "included"}, 422),
+        ],
+    )
+    def test_put(self, id_, data, status_code, app, client, admin_headers, db_session):
+        with app.test_request_context():
+            url = flask.url_for(
+                "fulltext_screenings_fulltext_screenings_resource", id=id_
+            )
+        response = client.put(url, json=data, headers=admin_headers)
+        assert response.status_code == status_code
+        if 200 <= status_code < 300:
+            data = response.json
+            for key, val in data.items():
+                assert data.get(key) == val
+
+    @pytest.mark.parametrize("id_", [1, 2])
+    def test_delete(self, id_, app, client, admin_headers, db_session):
+        with app.test_request_context():
+            url = flask.url_for(
+                "fulltext_screenings_fulltext_screenings_resource", id=id_
+            )
+        response = client.delete(url, headers=admin_headers)
+        # NOTE: this operation is currently only allowed for the screener themself
+        assert response.status_code == 403
+        # get_response = client.get(url, headers=admin_headers)
+        # assert get_response.status_code == 404  # not found!
+
+    @pytest.mark.parametrize(
+        ["fulltext_id", "data", "status_code"],
+        [
+            (2, {"user_id": 3, "review_id": 1, "status": "included"}, 200),
+            (999, {"status": "included"}, 404),
+        ],
+    )
+    def test_post(
+        self, fulltext_id, data, status_code, app, client, admin_headers, db_session
+    ):
+        with app.test_request_context():
+            url = flask.url_for(
+                "fulltext_screenings_fulltext_screenings_resource", id=fulltext_id
+            )
+        response = client.post(url, json=data, headers=admin_headers)
+        assert response.status_code == status_code
+        if 200 <= status_code < 300:
+            data = response.json
+            for key, val in data.items():
+                assert data.get(key) == val
+
+
+class TestFulltextsScreeningsResource:
+    @pytest.mark.parametrize(
+        ["params", "num_exp"],
+        [
+            ({"fulltext_id": 2}, 1),
+            ({"user_id": 2}, 2),
+            ({"review_id": 1}, 3),
+            ({"review_id": 1, "user_id": 3}, 1),
+        ],
+    )
+    def test_get(self, params, num_exp, app, client, admin_headers):
+        with app.test_request_context():
+            url = flask.url_for(
+                "fulltext_screenings_fulltexts_screenings_resource", **params
+            )
+        response = client.get(url, headers=admin_headers)
+        assert response.status_code == 200
+        response_data = response.json
+        assert isinstance(response_data, list)
+        assert len(response_data) == num_exp

--- a/tests/api/test_fulltexts.py
+++ b/tests/api/test_fulltexts.py
@@ -1,0 +1,38 @@
+import flask
+import pytest
+
+
+class TestFulltextResource:
+    @pytest.mark.parametrize(
+        ["id_", "params", "status_code"],
+        [
+            (1, None, 200),
+            (2, None, 200),
+            (1, {"fields": "id,review_id"}, 200),
+            (1, {"fields": "filename"}, 200),
+            (999, None, 404),
+        ],
+    )
+    def test_get(self, id_, params, status_code, app, client, admin_headers, seed_data):
+        with app.test_request_context():
+            url = flask.url_for("fulltexts_fulltext_resource", id=id_, **(params or {}))
+        response = client.get(url, headers=admin_headers)
+        assert response.status_code == status_code
+        if 200 <= status_code < 300:
+            data = response.json
+            fields = None if params is None else params["fields"].split(",")
+            if fields is not None and "id" not in fields:
+                fields.append("id")
+            assert "id" in data
+            assert data["id"] == id_
+            if fields:
+                assert sorted(data.keys()) == sorted(fields)
+
+    @pytest.mark.parametrize("id_", [1, 2])
+    def test_delete(self, id_, app, client, admin_headers, db_session):
+        with app.test_request_context():
+            url = flask.url_for("fulltexts_fulltext_resource", id=id_)
+        response = client.delete(url, headers=admin_headers)
+        assert response.status_code == 204
+        get_response = client.get(url, headers=admin_headers)
+        assert get_response.status_code == 404  # not found!

--- a/tests/api/test_review_plans.py
+++ b/tests/api/test_review_plans.py
@@ -26,10 +26,9 @@ class TestReviewPlanResource:
                 fields.append("id")
             assert "id" in data
             assert data["id"] == id
-            # TODO: figure out why these fields are null in the db :/
-            # for field in ["objective", "pico"]:
-            #     if fields is None or field in fields:
-            #         assert data[field] == seed_data.get(field)
+            for field in ["objective", "pico"]:
+                if fields is None or field in fields:
+                    assert data[field] == seed_data.get(field)
             if fields:
                 assert sorted(data.keys()) == sorted(fields)
 

--- a/tests/api/test_review_progress.py
+++ b/tests/api/test_review_progress.py
@@ -1,0 +1,109 @@
+import flask
+import pytest
+
+
+class TestReviewProgressResource:
+    @pytest.mark.parametrize(
+        ["id_", "params", "status_code"],
+        [
+            (1, {}, 200),
+            (1, {"step": "planning"}, 200),
+            (2, {}, 200),
+            (1, {"user_view": True}, 200),
+            (999, {}, 404),
+        ],
+    )
+    def test_get(self, id_, params, status_code, app, client, admin_headers):
+        with app.test_request_context():
+            url = flask.url_for(
+                "review_progress_review_progress_resource", id=id_, **params
+            )
+        response = client.get(url, headers=admin_headers)
+        assert response.status_code == status_code
+        if 200 <= status_code < 300:
+            data = response.json
+            assert data
+            assert isinstance(data, dict)
+            if "step" in params and params["step"] != "all":
+                assert len(data) == 1
+                assert params["step"] in data
+            else:
+                assert len(data) == 4
+                assert all(
+                    step in data
+                    for step in [
+                        "planning",
+                        "citation_screening",
+                        "fulltext_screening",
+                        "data_extraction",
+                    ]
+                )
+
+    @pytest.mark.parametrize(
+        ["id_", "exp_data"],
+        [
+            (
+                1,
+                {
+                    "planning": {
+                        "objective": True,
+                        "research_questions": True,
+                        "pico": True,
+                        "keyterms": True,
+                        "selection_criteria": True,
+                        "data_extraction_form": True,
+                    },
+                    "citation_screening": {
+                        "not_screened": 0,
+                        "screened_once": 0,
+                        "conflict": 0,
+                        "included": 2,
+                        "excluded": 1,
+                    },
+                    "fulltext_screening": {
+                        "not_screened": 0,
+                        "screened_once": 0,
+                        "conflict": 0,
+                        "included": 1,
+                        "excluded": 1,
+                    },
+                    "data_extraction": {"not_started": 1, "started": 0, "finished": 0},
+                },
+            ),
+            (
+                2,
+                {
+                    "planning": {
+                        "objective": False,
+                        "research_questions": False,
+                        "pico": False,
+                        "keyterms": False,
+                        "selection_criteria": False,
+                        "data_extraction_form": False,
+                    },
+                    "citation_screening": {
+                        "not_screened": 0,
+                        "screened_once": 0,
+                        "conflict": 0,
+                        "included": 1,
+                        "excluded": 0,
+                    },
+                    "fulltext_screening": {
+                        "not_screened": 1,
+                        "screened_once": 0,
+                        "conflict": 0,
+                        "included": 0,
+                        "excluded": 0,
+                    },
+                    "data_extraction": {"not_started": 0, "started": 0, "finished": 0},
+                },
+            ),
+        ],
+    )
+    def test_exp_result(self, id_, exp_data, app, client, admin_headers):
+        with app.test_request_context():
+            url = flask.url_for("review_progress_review_progress_resource", id=id_)
+        response = client.get(url, headers=admin_headers)
+        assert response.status_code == 200
+        data = response.json
+        assert data == exp_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pathlib
 import shutil
 
 import pytest
+import sqlalchemy as sa
 
 from colandr import extensions, models
 from colandr.app import create_app
@@ -57,9 +58,10 @@ def _populate_db(db, seed_data):
         db.session.add(user)
     for record in seed_data["reviews"]:
         db.session.add(models.Review(**record))
-    for record in seed_data["review_plans"]:
-        # NOTE: this automatically adds the relationship to associated review
-        _ = models.ReviewPlan(**record)
+    # for record in seed_data["review_plans"]:
+    #     # NOTE: this automatically adds the relationship to associated review
+    #     # _ = models.ReviewPlan(**record)
+    #     db.session.add(models.ReviewPlan(**record))
     for record in seed_data["data_sources"]:
         db.session.add(models.DataSource(**record))
     for record in seed_data["studies"]:
@@ -67,6 +69,8 @@ def _populate_db(db, seed_data):
     for record in seed_data["citations"]:
         db.session.add(models.Citation(**record))
     db.session.commit()
+    # empty review plans already created w/ review
+    db.session.execute(sa.update(models.ReviewPlan), seed_data["review_plans"])
     for record in seed_data["citation_screenings"]:
         db.session.add(models.CitationScreening(**record))
     for record in seed_data["fulltext_uploads"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,8 @@ def _populate_db(db, seed_data):
         for key, val in record.items():
             if key != "id":
                 setattr(fulltext, key, val)
+    for record in seed_data["fulltext_screenings"]:
+        db.session.add(models.FulltextScreening(**record))
     # # TODO: figure out why this doesn't work :/
     # for record in seed_data["review_teams"]:
     #     review = db.session.query(models.Review).get(record["id"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,10 +58,6 @@ def _populate_db(db, seed_data):
         db.session.add(user)
     for record in seed_data["reviews"]:
         db.session.add(models.Review(**record))
-    # for record in seed_data["review_plans"]:
-    #     # NOTE: this automatically adds the relationship to associated review
-    #     # _ = models.ReviewPlan(**record)
-    #     db.session.add(models.ReviewPlan(**record))
     for record in seed_data["data_sources"]:
         db.session.add(models.DataSource(**record))
     for record in seed_data["studies"]:
@@ -70,7 +66,11 @@ def _populate_db(db, seed_data):
         db.session.add(models.Citation(**record))
     db.session.commit()
     # empty review plans already created w/ review
-    db.session.execute(sa.update(models.ReviewPlan), seed_data["review_plans"])
+    for record in seed_data["review_plans"]:
+        plan = db.session.query(models.ReviewPlan).get(record["id_"])
+        for key, val in record.items():
+            if key != "id_":
+                setattr(plan, key, val)
     for record in seed_data["citation_screenings"]:
         db.session.add(models.CitationScreening(**record))
     for record in seed_data["fulltext_uploads"]:

--- a/tests/fixtures/seed_data.json
+++ b/tests/fixtures/seed_data.json
@@ -337,5 +337,29 @@
             "original_filename": "example-journal.pdf",
             "text_content": "TEXT_CONTENT2"
         }
+    ],
+    "fulltext_screenings": [
+        {
+            "user_id": 2,
+            "review_id": 1,
+            "fulltext_id": 1,
+            "status": "included"
+        },
+        {
+            "user_id": 3,
+            "review_id": 1,
+            "fulltext_id": 1,
+            "status": "included"
+        },
+        {
+            "user_id": 2,
+            "review_id": 1,
+            "fulltext_id": 2,
+            "status": "excluded",
+            "exclude_reasons": [
+                "REASON1",
+                "REASON2"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
### changes

- grants admin users permission to create/delete/modify fulltext and fulltext screening records in the db via api
- adds unit tests for fulltexts and review progress api resources
- adds seed data and unit tests for fulltext screenings api resource
- fixes test setup for review plans api resource