### PR TITLE
Update db interface according to new sqlalchemy v2 api

### DIFF
--- a/colandr/apis/resources/citation_imports.py
+++ b/colandr/apis/resources/citation_imports.py
@@ -236,7 +236,7 @@ class CitationsImportsResource(Resource):
         # this method is required because not all citations have all fields
         for study_id, citation in zip(study_ids, citations_to_insert):
             citation["id"] = study_id
-        db.session.bulk_insert_mappings(Citation, citations_to_insert)
+        db.session.execute(sa.insert(Citation), citations_to_insert)
 
         # if citations' status is "included", we have to bulk insert
         # the corresponding fulltexts, since bulk operations won't trigger

--- a/colandr/apis/resources/citation_screenings.py
+++ b/colandr/apis/resources/citation_screenings.py
@@ -402,7 +402,7 @@ class CitationsScreeningsResource(Resource):
             screening["review_id"] = review_id
             screening["user_id"] = screener_user_id
             screenings_to_insert.append(screening)
-        db.session.bulk_insert_mappings(CitationScreening, screenings_to_insert)
+        db.session.execute(sa.insert(CitationScreening), screenings_to_insert)
         db.session.commit()
         current_app.logger.info(
             "inserted %s citation screenings", len(screenings_to_insert)
@@ -430,7 +430,7 @@ class CitationsScreeningsResource(Resource):
             for row in results
         ]
 
-        db.session.bulk_update_mappings(Study, studies_to_update)
+        db.session.execute(sa.update(Study), studies_to_update)
         db.session.commit()
         current_app.logger.info(
             "updated citation_status for %s studies", len(studies_to_update)
@@ -447,7 +447,7 @@ class CitationsScreeningsResource(Resource):
         fulltexts_to_insert = [
             {"id": result, "review_id": review_id} for result in results
         ]
-        db.session.bulk_insert_mappings(Fulltext, fulltexts_to_insert)
+        db.session.execute(sa.insert(Fulltext), fulltexts_to_insert)
         db.session.commit()
         current_app.logger.info("inserted %s fulltexts", len(fulltexts_to_insert))
         # now update include/exclude counts on review

--- a/colandr/apis/resources/fulltext_screenings.py
+++ b/colandr/apis/resources/fulltext_screenings.py
@@ -399,7 +399,7 @@ class FulltextsScreeningsResource(Resource):
             screening["review_id"] = review_id
             screening["user_id"] = screener_user_id
             screenings_to_insert.append(screening)
-        db.session.bulk_insert_mappings(FulltextScreening, screenings_to_insert)
+        db.session.execute(sa.insert(FulltextScreening), screenings_to_insert)
         db.session.commit()
         current_app.logger.info(
             "inserted %s fulltext screenings", len(screenings_to_insert)
@@ -427,7 +427,7 @@ class FulltextsScreeningsResource(Resource):
             for row in results
         ]
 
-        db.session.bulk_update_mappings(Study, studies_to_update)
+        db.session.execute(sa.update(Study), studies_to_update)
         db.session.commit()
         current_app.logger.info(
             "updated fulltext_status for %s studies", len(studies_to_update)
@@ -444,7 +444,7 @@ class FulltextsScreeningsResource(Resource):
         data_extractions_to_insert = [
             {"id": result, "review_id": review_id} for result in results
         ]
-        db.session.bulk_insert_mappings(DataExtraction, data_extractions_to_insert)
+        db.session.execute(sa.insert(DataExtraction), data_extractions_to_insert)
         db.session.commit()
         current_app.logger.info(
             "inserted %s data extractions", len(data_extractions_to_insert)

--- a/colandr/config.py
+++ b/colandr/config.py
@@ -27,8 +27,6 @@ SQLALCHEMY_DATABASE_URI = os.environ["COLANDR_DATABASE_URI"]
 #     f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:5432/{DB_NAME}"
 # )
 SQLALCHEMY_ECHO = False
-# TODO: figure out why future-style sqlalchemy usage fails catastrophically
-# SQLALCHEMY_ENGINE_OPTIONS = {"future": True}
 
 # celery+redis config
 CELERY = {

--- a/colandr/extensions.py
+++ b/colandr/extensions.py
@@ -1,13 +1,22 @@
+# import typing
+
 import celery
 import flask_caching
 import flask_jwt_extended
 import flask_mail
 import flask_migrate
 import flask_sqlalchemy
+import sqlalchemy.orm
+# from sqlalchemy.dialects import postgresql
+
+
+class _BaseModel(sqlalchemy.orm.DeclarativeBase):
+    # type_annotation_map = {dict[str, typing.Any]: postgresql.JSON}
+    pass
 
 
 cache = flask_caching.Cache()
-db = flask_sqlalchemy.SQLAlchemy()
+db = flask_sqlalchemy.SQLAlchemy(model_class=_BaseModel)
 jwt = flask_jwt_extended.JWTManager()
 mail = flask_mail.Mail()
 migrate = flask_migrate.Migrate()

--- a/colandr/models.py
+++ b/colandr/models.py
@@ -94,31 +94,31 @@ class Review(db.Model):
     __tablename__ = "reviews"
 
     # columns
-    id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
-    created_at = sa.Column(
+    id = mapcol(sa.Integer, primary_key=True, autoincrement=True)
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    name = sa.Column(sa.String(length=500), nullable=False)
-    description = sa.Column(sa.Text)
-    status = sa.Column(sa.String(length=25), server_default="active", nullable=False)
-    num_citation_screening_reviewers = sa.Column(
+    name = mapcol(sa.String(length=500), nullable=False)
+    description = mapcol(sa.Text)
+    status = mapcol(sa.String(length=25), server_default="active", nullable=False)
+    num_citation_screening_reviewers = mapcol(
         sa.SmallInteger, server_default="1", nullable=False
     )
-    num_fulltext_screening_reviewers = sa.Column(
+    num_fulltext_screening_reviewers = mapcol(
         sa.SmallInteger, server_default="1", nullable=False
     )
-    num_citations_included = sa.Column(sa.Integer, server_default="0", nullable=False)
-    num_citations_excluded = sa.Column(sa.Integer, server_default="0", nullable=False)
-    num_fulltexts_included = sa.Column(sa.Integer, server_default="0", nullable=False)
-    num_fulltexts_excluded = sa.Column(sa.Integer, server_default="0", nullable=False)
+    num_citations_included = mapcol(sa.Integer, server_default="0", nullable=False)
+    num_citations_excluded = mapcol(sa.Integer, server_default="0", nullable=False)
+    num_fulltexts_included = mapcol(sa.Integer, server_default="0", nullable=False)
+    num_fulltexts_excluded = mapcol(sa.Integer, server_default="0", nullable=False)
 
     # relationships
     review_user_assoc = db.relationship(
@@ -189,19 +189,19 @@ class Review(db.Model):
 class ReviewUserAssoc(db.Model):
     __tablename__ = "review_user_assoc"
 
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer, sa.ForeignKey("reviews.id", ondelete="CASCADE"), primary_key=True
     )
-    user_id = sa.Column(
+    user_id = mapcol(
         sa.Integer, sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
     )
-    user_role = sa.Column(sa.Text, nullable=False, server_default=sa.text("'member'"))
-    created_at = sa.Column(
+    user_role = mapcol(sa.Text, nullable=False, server_default=sa.text("'member'"))
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    updated_at = sa.Column(
+    updated_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
@@ -224,33 +224,33 @@ class ReviewPlan(db.Model):
     __tablename__ = "review_plans"
 
     # columns
-    id = sa.Column(
+    id = mapcol(
         sa.BigInteger, sa.ForeignKey("reviews.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = sa.Column(
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    objective = sa.Column(sa.Text)
-    research_questions = sa.Column(
+    objective = mapcol(sa.Text)
+    research_questions = mapcol(
         postgresql.ARRAY(sa.String(length=300)), server_default="{}"
     )
-    pico = sa.Column(postgresql.JSONB(none_as_null=True), server_default="{}")
-    keyterms = sa.Column(postgresql.JSONB(none_as_null=True), server_default="{}")
-    selection_criteria = sa.Column(
+    pico = mapcol(postgresql.JSONB(none_as_null=True), server_default="{}")
+    keyterms = mapcol(postgresql.JSONB(none_as_null=True), server_default="{}")
+    selection_criteria = mapcol(
         postgresql.JSONB(none_as_null=True), server_default="{}"
     )
-    data_extraction_form = sa.Column(
+    data_extraction_form = mapcol(
         postgresql.JSONB(none_as_null=True), server_default="{}"
     )
-    suggested_keyterms = sa.Column(
+    suggested_keyterms = mapcol(
         postgresql.JSONB(none_as_null=True), server_default="{}"
     )
 
@@ -297,15 +297,15 @@ class DataSource(db.Model):
     )
 
     # columns
-    id = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-    created_at = sa.Column(
+    id = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    source_type = sa.Column(sa.String(length=20), nullable=False, index=True)
-    source_name = sa.Column(sa.String(length=100), index=True)
-    source_url = sa.Column(sa.String(length=500))
+    source_type = mapcol(sa.String(length=20), nullable=False, index=True)
+    source_name = mapcol(sa.String(length=100), index=True)
+    source_url = mapcol(sa.String(length=500))
 
     @hybrid_property
     def source_type_and_name(self):
@@ -335,32 +335,32 @@ class Import(db.Model):
     __tablename__ = "imports"
 
     # columns
-    id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
-    created_at = sa.Column(
+    id = mapcol(sa.Integer, primary_key=True, autoincrement=True)
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    user_id = sa.Column(
+    user_id = mapcol(
         sa.Integer,
         sa.ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
-    data_source_id = sa.Column(
+    data_source_id = mapcol(
         sa.BigInteger,
         sa.ForeignKey("data_sources.id", ondelete="SET NULL"),
         nullable=True,
     )
-    record_type = sa.Column(sa.String(length=10), nullable=False)
-    num_records = sa.Column(sa.Integer, nullable=False)
-    status = sa.Column(sa.String(length=20), server_default="not_screened")
+    record_type = mapcol(sa.String(length=10), nullable=False)
+    num_records = mapcol(sa.Integer, nullable=False)
+    status = mapcol(sa.String(length=20), server_default="not_screened")
 
     # relationships
     review = db.relationship(
@@ -394,49 +394,49 @@ class Study(db.Model):
     __tablename__ = "studies"
 
     # columns
-    id = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-    created_at = sa.Column(
+    id = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    user_id = sa.Column(
+    user_id = mapcol(
         sa.Integer,
         sa.ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    tags = sa.Column(
+    tags = mapcol(
         postgresql.ARRAY(sa.String(length=64)), server_default="{}", index=False
     )
-    data_source_id = sa.Column(
+    data_source_id = mapcol(
         sa.Integer,
         sa.ForeignKey("data_sources.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
-    dedupe_status = sa.Column(
+    dedupe_status = mapcol(
         sa.String(length=20), server_default="not_duplicate", nullable=True, index=True
     )
-    citation_status = sa.Column(
+    citation_status = mapcol(
         sa.String(length=20), server_default="not_screened", nullable=False, index=True
     )
-    fulltext_status = sa.Column(
+    fulltext_status = mapcol(
         sa.String(length=20), server_default="not_screened", nullable=False, index=True
     )
-    data_extraction_status = sa.Column(
+    data_extraction_status = mapcol(
         sa.String(length=20), server_default="not_started", nullable=False, index=True
     )
 
@@ -490,25 +490,25 @@ class Dedupe(db.Model):
     __tablename__ = "dedupes"
 
     # columns
-    id = sa.Column(
+    id = mapcol(
         sa.BigInteger, sa.ForeignKey("studies.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = sa.Column(
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    duplicate_of = sa.Column(
+    duplicate_of = mapcol(
         sa.BigInteger,
         nullable=True,  # sa.ForeignKey('studies.id', ondelete='SET NULL'),
     )
-    duplicate_score = sa.Column(sa.Float, nullable=True)
+    duplicate_score = mapcol(sa.Float, nullable=True)
 
     # relationships
     study = db.relationship(
@@ -540,44 +540,44 @@ class Citation(db.Model):
     #     )
 
     # columns
-    id = sa.Column(
+    id = mapcol(
         sa.BigInteger, sa.ForeignKey("studies.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = sa.Column(
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    type_of_work = sa.Column(sa.String(length=25))
-    title = sa.Column(sa.String(length=300), server_default="untitled", nullable=False)
-    secondary_title = sa.Column(sa.String(length=300))
-    abstract = sa.Column(sa.Text)
-    pub_year = sa.Column(sa.SmallInteger)
-    pub_month = sa.Column(sa.SmallInteger)
-    authors = sa.Column(postgresql.ARRAY(sa.String(length=100)))
-    keywords = sa.Column(postgresql.ARRAY(sa.String(length=100)))
-    type_of_reference = sa.Column(sa.String(length=50))
-    journal_name = sa.Column(sa.String(length=100))
-    volume = sa.Column(sa.String(length=20))
-    issue_number = sa.Column(sa.String(length=20))
-    doi = sa.Column(sa.String(length=100))
-    issn = sa.Column(sa.String(length=20))
-    publisher = sa.Column(sa.String(length=100))
-    language = sa.Column(sa.String(length=50))
-    other_fields = sa.Column(postgresql.JSONB(none_as_null=True), server_default="{}")
-    text_content_vector_rep = sa.Column(postgresql.ARRAY(sa.Float), server_default="{}")
+    type_of_work = mapcol(sa.String(length=25))
+    title = mapcol(sa.String(length=300), server_default="untitled", nullable=False)
+    secondary_title = mapcol(sa.String(length=300))
+    abstract = mapcol(sa.Text)
+    pub_year = mapcol(sa.SmallInteger)
+    pub_month = mapcol(sa.SmallInteger)
+    authors = mapcol(postgresql.ARRAY(sa.String(length=100)))
+    keywords = mapcol(postgresql.ARRAY(sa.String(length=100)))
+    type_of_reference = mapcol(sa.String(length=50))
+    journal_name = mapcol(sa.String(length=100))
+    volume = mapcol(sa.String(length=20))
+    issue_number = mapcol(sa.String(length=20))
+    doi = mapcol(sa.String(length=100))
+    issn = mapcol(sa.String(length=20))
+    publisher = mapcol(sa.String(length=100))
+    language = mapcol(sa.String(length=50))
+    other_fields = mapcol(postgresql.JSONB(none_as_null=True), server_default="{}")
+    text_content_vector_rep = mapcol(postgresql.ARRAY(sa.Float), server_default="{}")
 
     @hybrid_property
     def text_content(self):
@@ -665,30 +665,30 @@ class Fulltext(db.Model):
     __tablename__ = "fulltexts"
 
     # columns
-    id = sa.Column(
+    id = mapcol(
         sa.BigInteger, sa.ForeignKey("studies.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = sa.Column(
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    filename = sa.Column(sa.String(length=30), unique=True, nullable=True)
-    original_filename = sa.Column(sa.String, unique=False, nullable=True)
-    text_content = sa.Column(sa.Text, nullable=True)
-    text_content_vector_rep = sa.Column(postgresql.ARRAY(sa.Float), server_default="{}")
+    filename = mapcol(sa.String(length=30), unique=True, nullable=True)
+    original_filename = mapcol(sa.String, unique=False, nullable=True)
+    text_content = mapcol(sa.Text, nullable=True)
+    text_content_vector_rep = mapcol(postgresql.ARRAY(sa.Float), server_default="{}")
 
     @hybrid_property
     def exclude_reasons(self):
@@ -733,38 +733,38 @@ class CitationScreening(db.Model):
     )
 
     # columns
-    id = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-    created_at = sa.Column(
+    id = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    user_id = sa.Column(
+    user_id = mapcol(
         sa.Integer,
         sa.ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
-    citation_id = sa.Column(
+    citation_id = mapcol(
         sa.BigInteger,
         sa.ForeignKey("citations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    status = sa.Column(sa.String(length=20), nullable=False, index=True)
-    exclude_reasons = sa.Column(postgresql.ARRAY(sa.String(length=64)), nullable=True)
+    status = mapcol(sa.String(length=20), nullable=False, index=True)
+    exclude_reasons = mapcol(postgresql.ARRAY(sa.String(length=64)), nullable=True)
 
     # relationships
     user = db.relationship(
@@ -806,38 +806,38 @@ class FulltextScreening(db.Model):
     )
 
     # columns
-    id = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-    created_at = sa.Column(
+    id = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    user_id = sa.Column(
+    user_id = mapcol(
         sa.Integer,
         sa.ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
-    fulltext_id = sa.Column(
+    fulltext_id = mapcol(
         sa.BigInteger,
         sa.ForeignKey("fulltexts.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    status = sa.Column(sa.String(length=20), nullable=False, index=True)
-    exclude_reasons = sa.Column(postgresql.ARRAY(sa.String(length=64)), nullable=True)
+    status = mapcol(sa.String(length=20), nullable=False, index=True)
+    exclude_reasons = mapcol(postgresql.ARRAY(sa.String(length=64)), nullable=True)
 
     # relationships
     user = db.relationship(
@@ -874,29 +874,27 @@ class DataExtraction(db.Model):
     __tablename__ = "data_extractions"
 
     # columns
-    id = sa.Column(
+    id = mapcol(
         sa.BigInteger, sa.ForeignKey("studies.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = sa.Column(
+    created_at = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated = mapcol(
         sa.DateTime(timezone=False),
         nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = sa.Column(
+    review_id = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    extracted_items = sa.Column(
-        postgresql.JSONB(none_as_null=True), server_default="{}"
-    )
+    extracted_items = mapcol(postgresql.JSONB(none_as_null=True), server_default="{}")
 
     # relationships
     study = db.relationship(

--- a/colandr/models.py
+++ b/colandr/models.py
@@ -73,7 +73,7 @@ class User(db.Model):
         ]
 
     @property
-    def password(self):
+    def password(self) -> str:
         """User's (automatically hashed) password."""
         return self._password
 
@@ -94,31 +94,29 @@ class Review(db.Model):
     __tablename__ = "reviews"
 
     # columns
-    id = mapcol(sa.Integer, primary_key=True, autoincrement=True)
-    created_at = mapcol(
+    id: M[int] = mapcol(sa.Integer, primary_key=True, autoincrement=True)
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = mapcol(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    name = mapcol(sa.String(length=500), nullable=False)
-    description = mapcol(sa.Text)
-    status = mapcol(sa.String(length=25), server_default="active", nullable=False)
-    num_citation_screening_reviewers = mapcol(
-        sa.SmallInteger, server_default="1", nullable=False
+    name: M[str] = mapcol(sa.String(length=500))
+    description: M[Optional[str]] = mapcol(sa.Text)
+    status: M[str] = mapcol(sa.String(length=25), server_default="active")
+    num_citation_screening_reviewers: M[int] = mapcol(
+        sa.SmallInteger, server_default="1"
     )
-    num_fulltext_screening_reviewers = mapcol(
-        sa.SmallInteger, server_default="1", nullable=False
+    num_fulltext_screening_reviewers: M[int] = mapcol(
+        sa.SmallInteger, server_default="1"
     )
-    num_citations_included = mapcol(sa.Integer, server_default="0", nullable=False)
-    num_citations_excluded = mapcol(sa.Integer, server_default="0", nullable=False)
-    num_fulltexts_included = mapcol(sa.Integer, server_default="0", nullable=False)
-    num_fulltexts_excluded = mapcol(sa.Integer, server_default="0", nullable=False)
+    num_citations_included: M[int] = mapcol(sa.Integer, server_default="0")
+    num_citations_excluded: M[int] = mapcol(sa.Integer, server_default="0")
+    num_fulltexts_included: M[int] = mapcol(sa.Integer, server_default="0")
+    num_fulltexts_excluded: M[int] = mapcol(sa.Integer, server_default="0")
 
     # relationships
     review_user_assoc = db.relationship(
@@ -189,21 +187,21 @@ class Review(db.Model):
 class ReviewUserAssoc(db.Model):
     __tablename__ = "review_user_assoc"
 
-    review_id = mapcol(
+    review_id: M[int] = mapcol(
         sa.Integer, sa.ForeignKey("reviews.id", ondelete="CASCADE"), primary_key=True
     )
-    user_id = mapcol(
+    user_id: M[int] = mapcol(
         sa.Integer, sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
     )
-    user_role = mapcol(sa.Text, nullable=False, server_default=sa.text("'member'"))
-    created_at = mapcol(
+    user_role: M[Optional[str]] = mapcol(
+        sa.Text, nullable=False, server_default=sa.text("'member'")
+    )
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    updated_at = mapcol(
+    updated_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
@@ -224,23 +222,22 @@ class ReviewPlan(db.Model):
     __tablename__ = "review_plans"
 
     # columns
-    id = mapcol(
+    id: M[int] = mapcol(
         sa.BigInteger, sa.ForeignKey("reviews.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = mapcol(
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = mapcol(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    objective = mapcol(sa.Text)
+    objective: M[Optional[str]] = mapcol(sa.Text)
     research_questions = mapcol(
-        postgresql.ARRAY(sa.String(length=300)), server_default="{}"
+        postgresql.ARRAY(sa.String(length=300)),
+        server_default="{}",
     )
     pico = mapcol(postgresql.JSONB(none_as_null=True), server_default="{}")
     keyterms = mapcol(postgresql.JSONB(none_as_null=True), server_default="{}")
@@ -297,15 +294,14 @@ class DataSource(db.Model):
     )
 
     # columns
-    id = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
-    created_at = mapcol(
+    id: M[int] = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    source_type = mapcol(sa.String(length=20), nullable=False, index=True)
-    source_name = mapcol(sa.String(length=100), index=True)
-    source_url = mapcol(sa.String(length=500))
+    source_type: M[str] = mapcol(sa.String(length=20), index=True)
+    source_name: M[Optional[str]] = mapcol(sa.String(length=100), index=True)
+    source_url: M[Optional[str]] = mapcol(sa.String(length=500))
 
     @hybrid_property
     def source_type_and_name(self):
@@ -335,32 +331,25 @@ class Import(db.Model):
     __tablename__ = "imports"
 
     # columns
-    id = mapcol(sa.Integer, primary_key=True, autoincrement=True)
-    created_at = mapcol(
+    id: M[int] = mapcol(sa.Integer, primary_key=True, autoincrement=True)
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = mapcol(
-        sa.Integer,
-        sa.ForeignKey("reviews.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
+    review_id: M[int] = mapcol(
+        sa.Integer, sa.ForeignKey("reviews.id", ondelete="CASCADE"), index=True
     )
-    user_id = mapcol(
-        sa.Integer,
-        sa.ForeignKey("users.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
+    user_id: M[Optional[int]] = mapcol(
+        sa.Integer, sa.ForeignKey("users.id", ondelete="SET NULL"), index=True
     )
-    data_source_id = mapcol(
-        sa.BigInteger,
-        sa.ForeignKey("data_sources.id", ondelete="SET NULL"),
-        nullable=True,
+    data_source_id: M[Optional[int]] = mapcol(
+        sa.BigInteger, sa.ForeignKey("data_sources.id", ondelete="SET NULL")
     )
-    record_type = mapcol(sa.String(length=10), nullable=False)
-    num_records = mapcol(sa.Integer, nullable=False)
-    status = mapcol(sa.String(length=20), server_default="not_screened")
+    record_type: M[str] = mapcol(sa.String(length=10))
+    num_records: M[int] = mapcol(sa.Integer)
+    status: M[Optional[str]] = mapcol(
+        sa.String(length=20), server_default="not_screened"
+    )
 
     # relationships
     review = db.relationship(
@@ -394,50 +383,39 @@ class Study(db.Model):
     __tablename__ = "studies"
 
     # columns
-    id = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
-    created_at = mapcol(
+    id: M[int] = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = mapcol(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    user_id = mapcol(
-        sa.Integer,
-        sa.ForeignKey("users.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
+    user_id: M[Optional[int]] = mapcol(
+        sa.Integer, sa.ForeignKey("users.id", ondelete="SET NULL"), index=True
     )
-    review_id = mapcol(
-        sa.Integer,
-        sa.ForeignKey("reviews.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
+    review_id: M[int] = mapcol(
+        sa.Integer, sa.ForeignKey("reviews.id", ondelete="CASCADE"), index=True
     )
     tags = mapcol(
         postgresql.ARRAY(sa.String(length=64)), server_default="{}", index=False
     )
-    data_source_id = mapcol(
-        sa.Integer,
-        sa.ForeignKey("data_sources.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
+    data_source_id: M[Optional[int]] = mapcol(
+        sa.Integer, sa.ForeignKey("data_sources.id", ondelete="SET NULL"), index=True
     )
-    dedupe_status = mapcol(
-        sa.String(length=20), server_default="not_duplicate", nullable=True, index=True
+    dedupe_status: M[Optional[str]] = mapcol(
+        sa.String(length=20), server_default="not_duplicate", index=True
     )
-    citation_status = mapcol(
-        sa.String(length=20), server_default="not_screened", nullable=False, index=True
+    citation_status: M[str] = mapcol(
+        sa.String(length=20), server_default="not_screened", index=True
     )
-    fulltext_status = mapcol(
-        sa.String(length=20), server_default="not_screened", nullable=False, index=True
+    fulltext_status: M[str] = mapcol(
+        sa.String(length=20), server_default="not_screened", index=True
     )
-    data_extraction_status = mapcol(
-        sa.String(length=20), server_default="not_started", nullable=False, index=True
+    data_extraction_status: M[str] = mapcol(
+        sa.String(length=20), server_default="not_started", index=True
     )
 
     # relationships
@@ -490,25 +468,20 @@ class Dedupe(db.Model):
     __tablename__ = "dedupes"
 
     # columns
-    id = mapcol(
+    id: M[int] = mapcol(
         sa.BigInteger, sa.ForeignKey("studies.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = mapcol(
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = mapcol(
-        sa.Integer,
-        sa.ForeignKey("reviews.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
+    review_id: M[int] = mapcol(
+        sa.Integer, sa.ForeignKey("reviews.id", ondelete="CASCADE"), index=True
     )
-    duplicate_of = mapcol(
-        sa.BigInteger,
-        nullable=True,  # sa.ForeignKey('studies.id', ondelete='SET NULL'),
+    duplicate_of: M[Optional[int]] = mapcol(
+        sa.BigInteger,  # sa.ForeignKey('studies.id', ondelete='SET NULL'),
     )
-    duplicate_score = mapcol(sa.Float, nullable=True)
+    duplicate_score: M[Optional[float]] = mapcol(sa.Float)
 
     # relationships
     study = db.relationship(
@@ -540,42 +513,37 @@ class Citation(db.Model):
     #     )
 
     # columns
-    id = mapcol(
+    id: M[int] = mapcol(
         sa.BigInteger, sa.ForeignKey("studies.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = mapcol(
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = mapcol(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = mapcol(
-        sa.Integer,
-        sa.ForeignKey("reviews.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
+    review_id: M[int] = mapcol(
+        sa.Integer, sa.ForeignKey("reviews.id", ondelete="CASCADE"), index=True
     )
-    type_of_work = mapcol(sa.String(length=25))
-    title = mapcol(sa.String(length=300), server_default="untitled", nullable=False)
-    secondary_title = mapcol(sa.String(length=300))
-    abstract = mapcol(sa.Text)
-    pub_year = mapcol(sa.SmallInteger)
-    pub_month = mapcol(sa.SmallInteger)
+    type_of_work: M[Optional[str]] = mapcol(sa.String(length=25))
+    title: M[str] = mapcol(sa.String(length=300), server_default="untitled")
+    secondary_title: M[Optional[str]] = mapcol(sa.String(length=300))
+    abstract: M[Optional[str]] = mapcol(sa.Text)
+    pub_year: M[Optional[int]] = mapcol(sa.SmallInteger)
+    pub_month: M[Optional[int]] = mapcol(sa.SmallInteger)
     authors = mapcol(postgresql.ARRAY(sa.String(length=100)))
     keywords = mapcol(postgresql.ARRAY(sa.String(length=100)))
-    type_of_reference = mapcol(sa.String(length=50))
-    journal_name = mapcol(sa.String(length=100))
-    volume = mapcol(sa.String(length=20))
-    issue_number = mapcol(sa.String(length=20))
-    doi = mapcol(sa.String(length=100))
-    issn = mapcol(sa.String(length=20))
-    publisher = mapcol(sa.String(length=100))
-    language = mapcol(sa.String(length=50))
+    type_of_reference: M[Optional[str]] = mapcol(sa.String(length=50))
+    journal_name: M[Optional[str]] = mapcol(sa.String(length=100))
+    volume: M[Optional[str]] = mapcol(sa.String(length=20))
+    issue_number: M[Optional[str]] = mapcol(sa.String(length=20))
+    doi: M[Optional[str]] = mapcol(sa.String(length=100))
+    issn: M[Optional[str]] = mapcol(sa.String(length=20))
+    publisher: M[Optional[str]] = mapcol(sa.String(length=100))
+    language: M[Optional[str]] = mapcol(sa.String(length=50))
     other_fields = mapcol(postgresql.JSONB(none_as_null=True), server_default="{}")
     text_content_vector_rep = mapcol(postgresql.ARRAY(sa.Float), server_default="{}")
 
@@ -665,29 +633,24 @@ class Fulltext(db.Model):
     __tablename__ = "fulltexts"
 
     # columns
-    id = mapcol(
+    id: M[int] = mapcol(
         sa.BigInteger, sa.ForeignKey("studies.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = mapcol(
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = mapcol(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = mapcol(
-        sa.Integer,
-        sa.ForeignKey("reviews.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
+    review_id: M[int] = mapcol(
+        sa.Integer, sa.ForeignKey("reviews.id", ondelete="CASCADE"), index=True
     )
-    filename = mapcol(sa.String(length=30), unique=True, nullable=True)
-    original_filename = mapcol(sa.String, unique=False, nullable=True)
-    text_content = mapcol(sa.Text, nullable=True)
+    filename: M[Optional[str]] = mapcol(sa.String(length=30), unique=True)
+    original_filename: M[Optional[str]] = mapcol(sa.String, unique=False)
+    text_content: M[Optional[str]] = mapcol(sa.Text)
     text_content_vector_rep = mapcol(postgresql.ARRAY(sa.Float), server_default="{}")
 
     @hybrid_property
@@ -733,37 +696,32 @@ class CitationScreening(db.Model):
     )
 
     # columns
-    id = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
-    created_at = mapcol(
+    id: M[int] = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = mapcol(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = mapcol(
+    review_id: M[int] = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
-        nullable=False,
         index=True,
     )
-    user_id = mapcol(
+    user_id: M[Optional[int]] = mapcol(
         sa.Integer,
         sa.ForeignKey("users.id", ondelete="SET NULL"),
-        nullable=True,
         index=True,
     )
-    citation_id = mapcol(
+    citation_id: M[int] = mapcol(
         sa.BigInteger,
         sa.ForeignKey("citations.id", ondelete="CASCADE"),
-        nullable=False,
         index=True,
     )
-    status = mapcol(sa.String(length=20), nullable=False, index=True)
+    status: M[str] = mapcol(sa.String(length=20), index=True)
     exclude_reasons = mapcol(postgresql.ARRAY(sa.String(length=64)), nullable=True)
 
     # relationships
@@ -806,37 +764,32 @@ class FulltextScreening(db.Model):
     )
 
     # columns
-    id = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
-    created_at = mapcol(
+    id: M[int] = mapcol(sa.BigInteger, primary_key=True, autoincrement=True)
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = mapcol(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = mapcol(
+    review_id: M[int] = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
-        nullable=False,
         index=True,
     )
-    user_id = mapcol(
+    user_id: M[Optional[int]] = mapcol(
         sa.Integer,
         sa.ForeignKey("users.id", ondelete="SET NULL"),
-        nullable=True,
         index=True,
     )
-    fulltext_id = mapcol(
+    fulltext_id: M[int] = mapcol(
         sa.BigInteger,
         sa.ForeignKey("fulltexts.id", ondelete="CASCADE"),
-        nullable=False,
         index=True,
     )
-    status = mapcol(sa.String(length=20), nullable=False, index=True)
+    status: M[str] = mapcol(sa.String(length=20), index=True)
     exclude_reasons = mapcol(postgresql.ARRAY(sa.String(length=64)), nullable=True)
 
     # relationships
@@ -874,24 +827,21 @@ class DataExtraction(db.Model):
     __tablename__ = "data_extractions"
 
     # columns
-    id = mapcol(
+    id: M[int] = mapcol(
         sa.BigInteger, sa.ForeignKey("studies.id", ondelete="CASCADE"), primary_key=True
     )
-    created_at = mapcol(
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = mapcol(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    review_id = mapcol(
+    review_id: M[int] = mapcol(
         sa.Integer,
         sa.ForeignKey("reviews.id", ondelete="CASCADE"),
-        nullable=False,
         index=True,
     )
     extracted_items = mapcol(postgresql.JSONB(none_as_null=True), server_default="{}")

--- a/colandr/models.py
+++ b/colandr/models.py
@@ -10,7 +10,7 @@ from sqlalchemy import event as sa_event
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import mapped_column as mapcol, Mapped as M
+from sqlalchemy.orm import mapped_column as mapcol, Mapped as M, DynamicMapped as DM
 
 from . import tasks, utils
 from .extensions import db
@@ -42,7 +42,7 @@ class User(db.Model):
     is_admin: M[bool] = mapcol(sa.Boolean, server_default=sa.false())
 
     # relationships
-    review_user_assoc = sa_orm.relationship(
+    review_user_assoc: DM["ReviewUserAssoc"] = sa_orm.relationship(
         "ReviewUserAssoc",
         back_populates="user",
         cascade="all, delete",
@@ -50,16 +50,16 @@ class User(db.Model):
     )
     reviews = association_proxy("review_user_assoc", "review")
 
-    imports = sa_orm.relationship(
+    imports: DM["Import"] = sa_orm.relationship(
         "Import", back_populates="user", lazy="dynamic", passive_deletes=True
     )
-    studies = sa_orm.relationship(
+    studies: DM["Study"] = sa_orm.relationship(
         "Study", back_populates="user", lazy="dynamic", passive_deletes=True
     )
-    citation_screenings = sa_orm.relationship(
+    citation_screenings: DM["CitationScreening"] = sa_orm.relationship(
         "CitationScreening", back_populates="user", lazy="dynamic"
     )
-    fulltext_screenings = sa_orm.relationship(
+    fulltext_screenings: DM["FulltextScreening"] = sa_orm.relationship(
         "FulltextScreening", back_populates="user", lazy="dynamic"
     )
 
@@ -133,34 +133,34 @@ class Review(db.Model):
     review_plan: M["ReviewPlan"] = sa_orm.relationship(
         "ReviewPlan", back_populates="review", lazy="select", passive_deletes=True
     )
-    imports = sa_orm.relationship(
+    imports: DM["Import"] = sa_orm.relationship(
         "Import", back_populates="review", lazy="dynamic", passive_deletes=True
     )
-    studies = sa_orm.relationship(
+    studies: DM["Study"] = sa_orm.relationship(
         "Study", back_populates="review", lazy="dynamic", passive_deletes=True
     )
-    dedupes = sa_orm.relationship(
+    dedupes: DM["Dedupe"] = sa_orm.relationship(
         "Dedupe", back_populates="review", lazy="dynamic", passive_deletes=True
     )
-    citations = sa_orm.relationship(
+    citations: DM["Citation"] = sa_orm.relationship(
         "Citation", back_populates="review", lazy="dynamic", passive_deletes=True
     )
-    citation_screenings = sa_orm.relationship(
+    citation_screenings: DM["CitationScreening"] = sa_orm.relationship(
         "CitationScreening",
         back_populates="review",
         lazy="dynamic",
         passive_deletes=True,
     )
-    fulltexts = sa_orm.relationship(
+    fulltexts: DM["Fulltext"] = sa_orm.relationship(
         "Fulltext", back_populates="review", lazy="dynamic", passive_deletes=True
     )
-    fulltext_screenings = sa_orm.relationship(
+    fulltext_screenings: DM["FulltextScreening"] = sa_orm.relationship(
         "FulltextScreening",
         back_populates="review",
         lazy="dynamic",
         passive_deletes=True,
     )
-    data_extractions = sa_orm.relationship(
+    data_extractions: DM["DataExtraction"] = sa_orm.relationship(
         "DataExtraction", back_populates="review", lazy="dynamic", passive_deletes=True
     )
 
@@ -312,10 +312,10 @@ class DataSource(db.Model):
             return self.source_type
 
     # relationships
-    imports = sa_orm.relationship(
+    imports: DM["Import"] = sa_orm.relationship(
         "Import", back_populates="data_source", lazy="dynamic", passive_deletes=True
     )
-    studies = sa_orm.relationship(
+    studies: DM["Study"] = sa_orm.relationship(
         "Study", back_populates="data_source", lazy="dynamic", passive_deletes=True
     )
 
@@ -561,7 +561,7 @@ class Citation(db.Model):
     review: M["Review"] = sa_orm.relationship(
         "Review", foreign_keys=[review_id], back_populates="citations", lazy="select"
     )
-    screenings = sa_orm.relationship(
+    screenings: DM["CitationScreening"] = sa_orm.relationship(
         "CitationScreening",
         back_populates="citation",
         lazy="dynamic",
@@ -655,7 +655,7 @@ class Fulltext(db.Model):
     review: M["Review"] = sa_orm.relationship(
         "Review", foreign_keys=[review_id], back_populates="fulltexts", lazy="select"
     )
-    screenings = sa_orm.relationship(
+    screenings: DM["FulltextScreening"] = sa_orm.relationship(
         "FulltextScreening",
         back_populates="fulltext",
         lazy="dynamic",

--- a/colandr/models.py
+++ b/colandr/models.py
@@ -1,3 +1,4 @@
+import datetime
 import itertools
 import logging
 from typing import Optional
@@ -8,6 +9,7 @@ from sqlalchemy import event as sa_event
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import mapped_column as mapcol, Mapped as M
 
 from . import tasks, utils
 from .extensions import db
@@ -20,23 +22,21 @@ class User(db.Model):
     __tablename__ = "users"
 
     # columns
-    id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
-    created_at = sa.Column(
+    id: M[int] = mapcol(sa.Integer, primary_key=True, autoincrement=True)
+    created_at: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    last_updated = sa.Column(
+    last_updated: M[datetime.datetime] = mapcol(
         sa.DateTime(timezone=False),
-        nullable=False,
         server_default=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
         server_onupdate=sa.text("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"),
     )
-    name = sa.Column(sa.String(length=200), nullable=False)
-    email = sa.Column(sa.String(length=200), unique=True, nullable=False, index=True)
-    _password = sa.Column("password", sa.String(length=256), nullable=False)
-    is_confirmed = sa.Column(sa.Boolean, nullable=False, server_default=sa.false())
-    is_admin = sa.Column(sa.Boolean, nullable=False, server_default=sa.false())
+    name: M[str] = mapcol(sa.String(length=200))
+    email: M[str] = mapcol(sa.String(length=200), unique=True, index=True)
+    _password: M[str] = mapcol("password", sa.String(length=256))
+    is_confirmed: M[bool] = mapcol(sa.Boolean, server_default=sa.false())
+    is_admin: M[bool] = mapcol(sa.Boolean, server_default=sa.false())
 
     # relationships
     review_user_assoc = db.relationship(

--- a/colandr/tasks.py
+++ b/colandr/tasks.py
@@ -195,10 +195,8 @@ def deduplicate_citations(review_id: int):
         {"id": cid, "dedupe_status": "not_duplicate"} for cid in non_duplicate_cids
     )
 
-    # TODO: update this for sqlalchemy v2
-    # ref: https://docs.sqlalchemy.org/en/20/orm/queryguide/dml.html#orm-enabled-insert-update-and-delete-statements
-    db.session.bulk_update_mappings(Study, studies_to_update)
-    db.session.bulk_insert_mappings(Dedupe, dedupes_to_insert)
+    db.session.execute(sa.update(Study), studies_to_update)
+    db.session.execute(sa.insert(Dedupe), dedupes_to_insert)
     db.session.commit()
     LOGGER.info(
         "<Review(id=%s)>: found %s duplicate and %s non-duplicate citations",
@@ -244,7 +242,7 @@ def get_citations_text_content_vectors(review_id: int):
         lock.release()
         return
 
-    db.session.bulk_update_mappings(Citation, citations_to_update)
+    db.session.execute(sa.update(Citation), citations_to_update)
     db.session.commit()
     LOGGER.info(
         "<Review(id=%s)>: %s citation text_content_vector_reps updated",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ addopts = "--verbose"
 testpaths = ["tests"]
 
 [tool.ruff]
-# ignore line-length violations, None comparisons
-ignore = ["E501", "E711"]
+# ignore line-length violations, None comparisons, unused imports
+ignore = ["E501", "E711", "F401"]
 line-length = 88
 indent-width = 4
 target-version = "py310"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def app(tmp_path_factory):
     config_overrides = {
         "TESTING": True,
         "SQLALCHEMY_ECHO": True,
+        "SQLALCHEMY_RECORD_QUERIES": True,
         "FULLTEXT_UPLOADS_DIR": str(tmp_path_factory.mktemp("colandr_fulltexts")),
     }
     app = create_app(config_overrides)


### PR DESCRIPTION
### changes

- use v2's improved api for bulk orm inserts/updates
- use v2's typing-aware declarative orm api, for both columns and relationships, to improve usability of db models
- update sqlalchemy config for v2 tweaks

refs:
- https://docs.sqlalchemy.org/en/20/changelog/whatsnew_20.html#orm-declarative-models
- https://docs.sqlalchemy.org/en/20/changelog/whatsnew_20.html#optimized-orm-bulk-insert-now-implemented-for-all-backends-other-than-mysql