### PR TITLE
Add support for dynamic num citation/fulltext reviewers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,4 +7,5 @@
 - [ ] Improve and extend NLP functionality, just across the board
 - [ ] Enable https everywhere (via [let's encrypt](https://letsencrypt.org/)?)
 - [ ] Add a "deduplicate" button to front-end interface and only run dedupe jobs upon request
-- [ ] Allow for requiring multiple screeners on a configurable percentage of studies (for "rapid review" style projects)
+- [x] Allow for requiring multiple screeners on a configurable percentage of studies (for "rapid review" style projects)
+- [ ] Add filtering studies by number of citation/fulltext reviewers

--- a/colandr/apis/resources/citation_screenings.py
+++ b/colandr/apis/resources/citation_screenings.py
@@ -1,3 +1,5 @@
+import random
+
 import flask_jwt_extended as jwtext
 import sqlalchemy as sa
 from flask import current_app
@@ -453,28 +455,25 @@ class CitationsScreeningsResource(Resource):
             "inserted %s citation screenings", len(screenings_to_insert)
         )
         # bulk update citation statuses
-        num_screeners = review.num_citation_screening_reviewers
-        study_ids = sorted(s["study_id"] for s in screenings_to_insert)
-        # results = db.session.query(models.Screening)\
-        #     .filter(models.Screening.study_id.in_(study_ids))
-        # studies_to_update = [
-        #     {'id': cid, 'citation_status': assign_status(list(scrns), num_screeners)}
-        #     for cid, scrns in itertools.groupby(results, attrgetter('citation_id'))
-        #     ]
-        with db.engine.connect() as connection:
-            query = """
-                SELECT study_id, ARRAY_AGG(status)
-                FROM screenings
-                WHERE study_id IN ({study_ids})
-                GROUP BY study_id
-                ORDER BY study_id
-                """.format(study_ids=",".join(str(cid) for cid in study_ids))
-            results = connection.execute(sa.text(query))
+        study_ids: list[int] = sorted(s["study_id"] for s in screenings_to_insert)
+        study_num_citation_reviewers: list[int] = random.choices(
+            [num_pct["num"] for num_pct in review.citation_reviewer_num_pcts],
+            weights=[num_pct["pct"] for num_pct in review.citation_reviewer_num_pcts],
+            k=len(study_ids),
+        )
+        results = db.session.execute(
+            sa.select(
+                models.Screening.study_id, sa.func.array_agg(models.Screening.status)
+            )
+            .where(models.Screening.stage == "citation")
+            .where(models.Screening.study_id == sa.any_(study_ids))
+            .group_by(models.Screening.study_id)
+            .order_by(models.Screening.study_id)
+        )
         studies_to_update = [
-            {"id": row[0], "citation_status": assign_status(row[1], num_screeners)}
-            for row in results
+            {"id": row[0], "citation_status": assign_status(row[1], num_reviewers)}
+            for row, num_reviewers in zip(results, study_num_citation_reviewers)
         ]
-
         db.session.execute(sa.update(models.Study), studies_to_update)
         db.session.commit()
         current_app.logger.info(
@@ -484,7 +483,6 @@ class CitationsScreeningsResource(Resource):
         status_counts_stmt = (
             sa.select(models.Study.citation_status, db.func.count(1))
             .filter_by(review_id=review_id, dedupe_status="not_duplicate")
-            # .filter(models.Study.citation_status.in_(["included", "excluded"]))
             .filter(models.Study.citation_status == sa.any_(["included", "excluded"]))
             .group_by(models.Study.citation_status)
         )

--- a/colandr/apis/resources/reviews.py
+++ b/colandr/apis/resources/reviews.py
@@ -207,7 +207,8 @@ class ReviewsResource(Resource):
             reviews = current_user.reviews
         if fields and "id" not in fields:
             fields.append("id")
-        return ReviewSchema(only=fields, many=True).dump(reviews)
+        # return ReviewSchema(only=fields, many=True).dump(reviews)
+        return [_convert_review_v2_into_v1(review) for review in reviews]
 
     @ns.doc(
         expect=(review_model, "review data to be created"),
@@ -237,7 +238,8 @@ class ReviewsResource(Resource):
                 os.makedirs(dirname, exist_ok=True)
             except OSError:
                 pass  # TODO: fix this / the entire system for saving files to disk
-        return ReviewSchema().dump(review)
+        # return ReviewSchema().dump(review)
+        return _convert_review_v2_into_v1(review)
 
 
 def _is_allowed(

--- a/colandr/apis/resources/reviews.py
+++ b/colandr/apis/resources/reviews.py
@@ -148,13 +148,16 @@ class ReviewResource(Resource):
         db.session.commit()
         current_app.logger.info("modified %s", review)
         result = ReviewV2Schema().dump(review)
+        assert isinstance(result, dict)
         # HACK: hide the v2 schema (which matches the db) from the api
-        result["num_citation_screening_reviewers"] = result.pop(
-            "citation_reviewer_num_pcts"
-        )[0]["num"]
-        result["num_fulltext_screening_reviewers"] = result.pop(
-            "fulltext_reviewer_num_pcts"
-        )[0]["num"]
+        if result.get("citation_reviewer_num_pcts"):
+            result["num_citation_screening_reviewers"] = result.pop(
+                "citation_reviewer_num_pcts"
+            )[0]["num"]
+        if result.get("fulltext_reviewer_num_pcts"):
+            result["num_fulltext_screening_reviewers"] = result.pop(
+                "fulltext_reviewer_num_pcts"
+            )[0]["num"]
         return result
 
 

--- a/colandr/apis/resources/studies.py
+++ b/colandr/apis/resources/studies.py
@@ -158,6 +158,10 @@ class StudyResource(Resource):
         return StudySchema().dump(study)
 
 
+# TODO: add optional filter for num citation/fulltext reviewers
+# and maybe, finally, port these queries over to sqlalchemy orm
+
+
 @ns.route("")
 @ns.doc(
     summary="get collections of matching studies",

--- a/colandr/apis/schemas.py
+++ b/colandr/apis/schemas.py
@@ -28,6 +28,11 @@ class DataSourceSchema(Schema):
     source_type_and_name = fields.Str(dump_only=True)
 
 
+class ReviewerNumPct(Schema):
+    num = fields.Int(required=True, validate=Range(min=1, max=3))
+    pct = fields.Int(required=True, validate=Range(min=0, max=100))
+
+
 class ReviewSchema(Schema):
     id = fields.Int(dump_only=True)
     created_at = fields.DateTime(dump_only=True, format="iso")
@@ -35,8 +40,19 @@ class ReviewSchema(Schema):
     name = fields.Str(required=True, validate=Length(max=500))
     description = fields.Str(load_default=None)
     status = fields.Str(validate=OneOf(constants.REVIEW_STATUSES))
-    num_citation_screening_reviewers = fields.Int(validate=Range(min=1, max=2))
-    num_fulltext_screening_reviewers = fields.Int(validate=Range(min=1, max=2))
+    num_citation_screening_reviewers = fields.Int(validate=Range(min=1, max=3))
+    num_fulltext_screening_reviewers = fields.Int(validate=Range(min=1, max=3))
+
+
+class ReviewV2Schema(Schema):
+    id = fields.Int(dump_only=True)
+    created_at = fields.DateTime(dump_only=True, format="iso")
+    updated_at = fields.DateTime(dump_only=True, format="iso")
+    name = fields.Str(required=True, validate=Length(max=500))
+    description = fields.Str(load_default=None)
+    status = fields.Str(validate=OneOf(constants.REVIEW_STATUSES))
+    citation_reviewer_num_pcts = fields.List(fields.Nested(ReviewerNumPct))
+    fulltext_reviewer_num_pcts = fields.List(fields.Nested(ReviewerNumPct))
 
 
 class ReviewPlanPICO(Schema):

--- a/colandr/apis/swagger.py
+++ b/colandr/apis/swagger.py
@@ -34,11 +34,34 @@ data_source_model = ns.model(
     },
 )
 
+reviewer_num_pct_model = ns.model(
+    "ReviewerNumPct",
+    {"num": fields.Integer(min=1, max=3), "pct": fields.Integer(min=0, max=100)},
+)
+
 review_model = ns.model(
     "Review",
     {
         "name": fields.String(required=True, max_length=500),
         "description": fields.String,
+        "status": fields.String,
+        "num_citation_screening_reviewers": fields.Integer(min=1, max=3),
+        "num_fulltext_screening_reviewers": fields.Integer(min=1, max=3),
+    },
+)
+
+review_v2_model = ns.model(
+    "ReviewV2",
+    {
+        "name": fields.String(required=True, max_length=500),
+        "description": fields.String,
+        "status": fields.String,
+        "citation_reviewer_num_pcts": fields.List(
+            fields.Nested(reviewer_num_pct_model)
+        ),
+        "fulltext_reviewer_num_pcts": fields.List(
+            fields.Nested(reviewer_num_pct_model)
+        ),
     },
 )
 
@@ -113,7 +136,7 @@ review_plan_model = ns.model(
         "data_extraction_form": fields.List(
             fields.Nested(data_extraction_form_item_model)
         ),
-    }
+    },
     # 'suggested_keyterms': fields.Nested(review_plan_suggested_keyterms)}  # not user-set
 )
 

--- a/migrations/versions/78dbca61ed59_allow_dynamic_num_study_reviewers.py
+++ b/migrations/versions/78dbca61ed59_allow_dynamic_num_study_reviewers.py
@@ -1,0 +1,121 @@
+"""allow dynamic num study reviewers
+
+Revision ID: 78dbca61ed59
+Revises: ff8fa67b9273
+Create Date: 2024-05-07 02:47:03.793366
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "78dbca61ed59"
+down_revision = "ff8fa67b9273"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # add new num reviewer cols on studies
+    with op.batch_alter_table("studies", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "num_citation_reviewers",
+                sa.SmallInteger(),
+                server_default="1",
+                nullable=False,
+            ),
+        )
+        batch_op.add_column(
+            sa.Column(
+                "num_fulltext_reviewers",
+                sa.SmallInteger(),
+                server_default="1",
+                nullable=False,
+            )
+        )
+    # data migration
+    op.execute(
+        """
+        UPDATE studies
+        SET
+            num_citation_reviewers = reviews.num_citation_screening_reviewers,
+            num_fulltext_reviewers = reviews.num_fulltext_screening_reviewers
+        FROM reviews
+        WHERE studies.review_id = reviews.id
+        """
+    )
+
+    # add new num/pct cols
+    with op.batch_alter_table("reviews", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "citation_reviewer_num_pcts",
+                postgresql.JSONB(astext_type=sa.Text()),
+                server_default=sa.text('\'[{"num": 1, "pct": 100}]\'::json'),
+                nullable=False,
+            ),
+        )
+        batch_op.add_column(
+            sa.Column(
+                "fulltext_reviewer_num_pcts",
+                postgresql.JSONB(astext_type=sa.Text()),
+                server_default=sa.text('\'[{"num": 1, "pct": 100}]\'::json'),
+                nullable=False,
+            ),
+        )
+    # adapt num reviewer cols values to num/pct equivalents
+    op.execute(
+        """
+        UPDATE reviews
+        SET
+            citation_reviewer_num_pcts = json_build_array(json_build_object('num', num_citation_screening_reviewers, 'pct', 100)),
+            fulltext_reviewer_num_pcts = json_build_array(json_build_object('num', num_fulltext_screening_reviewers, 'pct', 100))
+        """
+    )
+    # delete old num reviewer cols
+    with op.batch_alter_table("reviews", schema=None) as batch_op:
+        batch_op.drop_column("num_fulltext_screening_reviewers")
+        batch_op.drop_column("num_citation_screening_reviewers")
+
+
+def downgrade():
+    with op.batch_alter_table("reviews", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "num_citation_screening_reviewers",
+                sa.SMALLINT(),
+                server_default=sa.text("'1'::smallint"),
+                autoincrement=False,
+                nullable=False,
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "num_fulltext_screening_reviewers",
+                sa.SMALLINT(),
+                server_default=sa.text("'1'::smallint"),
+                autoincrement=False,
+                nullable=False,
+            )
+        )
+    # data de-migration
+    op.execute(
+        """
+        UPDATE reviews
+        SET
+            num_citation_screening_reviewers = (citation_reviewer_num_pcts #>> '{0, num}')::smallint,
+            num_fulltext_screening_reviewers = (fulltext_reviewer_num_pcts #>> '{0, num}')::smallint
+        """
+    )
+
+    with op.batch_alter_table("reviews", schema=None) as batch_op:
+        batch_op.drop_column("fulltext_reviewer_num_pcts")
+        batch_op.drop_column("citation_reviewer_num_pcts")
+
+    with op.batch_alter_table("studies", schema=None) as batch_op:
+        batch_op.drop_column("num_fulltext_reviewers")
+        batch_op.drop_column("num_citation_reviewers")

--- a/tests/api/test_reviews.py
+++ b/tests/api/test_reviews.py
@@ -39,6 +39,8 @@ class TestReviewResource:
             (1, {"name": "NEW_REVIEW_NAME1"}, 200),
             (1, {"description": "NEW_DESCRIPTION1"}, 200),
             (2, {"name": "NEW_REVIEW_NAME2", "description": "NEW_DESCRIPTION2"}, 200),
+            (2, {"num_citation_screening_reviewers": 2}, 200),
+            (2, {"num_fulltext_screening_reviewers": 3}, 200),
             (999, {"name": "NEW_REVIEW_NAME999"}, 404),
         ],
     )
@@ -51,44 +53,6 @@ class TestReviewResource:
             data = response.json
             for key, val in params.items():
                 assert data.get(key) == val
-
-    @pytest.mark.parametrize(
-        ["id_", "params", "exp_key", "exp_val"],
-        [
-            (
-                1,
-                {"num_citation_screening_reviewers": 2},
-                "citation_reviewer_num_pcts",
-                [{"num": 2, "pct": 100}],
-            ),
-            (
-                1,
-                {"num_fulltext_screening_reviewers": 3},
-                "fulltext_reviewer_num_pcts",
-                [{"num": 3, "pct": 100}],
-            ),
-            (
-                1,
-                {
-                    "citation_reviewer_num_pcts": [
-                        {"num": 1, "pct": 75},
-                        {"num": 2, "pct": 25},
-                    ]
-                },
-                "citation_reviewer_num_pcts",
-                [{"num": 1, "pct": 75}, {"num": 2, "pct": 25}],
-            ),
-        ],
-    )
-    def test_put_reviewer_num_pcts(
-        self, id_, params, exp_key, exp_val, app, client, admin_headers
-    ):
-        with app.test_request_context():
-            url = flask.url_for("reviews_review_resource", id=id_)
-        response = client.put(url, json=params, headers=admin_headers)
-        assert response.status_code == 200
-        data = response.json
-        assert data.get(exp_key) == exp_val
 
     @pytest.mark.parametrize("id_", [1, 2])
     def test_delete(self, id_, app, client, admin_headers):

--- a/tests/api/test_reviews.py
+++ b/tests/api/test_reviews.py
@@ -52,6 +52,44 @@ class TestReviewResource:
             for key, val in params.items():
                 assert data.get(key) == val
 
+    @pytest.mark.parametrize(
+        ["id_", "params", "exp_key", "exp_val"],
+        [
+            (
+                1,
+                {"num_citation_screening_reviewers": 2},
+                "citation_reviewer_num_pcts",
+                [{"num": 2, "pct": 100}],
+            ),
+            (
+                1,
+                {"num_fulltext_screening_reviewers": 3},
+                "fulltext_reviewer_num_pcts",
+                [{"num": 3, "pct": 100}],
+            ),
+            (
+                1,
+                {
+                    "citation_reviewer_num_pcts": [
+                        {"num": 1, "pct": 75},
+                        {"num": 2, "pct": 25},
+                    ]
+                },
+                "citation_reviewer_num_pcts",
+                [{"num": 1, "pct": 75}, {"num": 2, "pct": 25}],
+            ),
+        ],
+    )
+    def test_put_reviewer_num_pcts(
+        self, id_, params, exp_key, exp_val, app, client, admin_headers
+    ):
+        with app.test_request_context():
+            url = flask.url_for("reviews_review_resource", id=id_)
+        response = client.put(url, json=params, headers=admin_headers)
+        assert response.status_code == 200
+        data = response.json
+        assert data.get(exp_key) == exp_val
+
     @pytest.mark.parametrize("id_", [1, 2])
     def test_delete(self, id_, app, client, admin_headers):
         with app.test_request_context():


### PR DESCRIPTION
### changes

- allows for specifying the number of citation/fulltext reviewers for percentages of studies rather than the same values for all studies, and stores the specific number of reviewers for a given study on the study record itself
- updates citation/fulltext screenings endpoints to correctly set per-study num reviewers
- updates review schema in database, but hides that change from the (v1) review api endpoints
- adds a db event listener that automatically updates study num reviewers whenever the review is updated; this isn't great, because _any_ update to a review record will trigger a non-trivial db operation; i was not able to work around this, womp
- adds a schema+data migration to account for the changes