### PR TITLE
Upgrade python, v3.10 => v3.11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10",]
+        python-version: ["3.10", "3.11"]
         # TODO: also run on macos-latest pending docker/colima issue
         os: [ubuntu-latest]
 
@@ -84,7 +84,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         cache: "pip"
         cache-dependency-path: "pyproject.toml"
     - name: Install dependencies
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         cache: "pip"
         cache-dependency-path: "pyproject.toml"
     - name: Install dependencies

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,11 +1,11 @@
-FROM python:3.10-slim AS base
+FROM python:3.11-slim AS base
 
 ENV COLANDR_APP_DIR /app
 RUN mkdir -p ${COLANDR_APP_DIR}
 WORKDIR ${COLANDR_APP_DIR}
 
 RUN apt update \
-    && apt install -y gcc git \
+    && apt install -y g++ git \
     && apt clean \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,11 +1,11 @@
-FROM python:3.10-slim AS base
+FROM python:3.11-slim AS base
 
 ENV COLANDR_APP_DIR /app
 RUN mkdir -p ${COLANDR_APP_DIR}
 WORKDIR ${COLANDR_APP_DIR}
 
 RUN apt update \
-    && apt install -y gcc git \
+    && apt install -y g++ git \
     && apt clean \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
   "alembic~=1.13.0",


### PR DESCRIPTION
### changes

- docker images are now based on py3.11, up from py3.10
- pyproject metadata now includes py3.11
- github workflows use 3.11, mostly