### PR TITLE
only allow admin users to add/remove other admins

### DIFF
--- a/colandr/apis/resources/users.py
+++ b/colandr/apis/resources/users.py
@@ -126,7 +126,13 @@ class UserResource(Resource):
             if key is missing:
                 continue
             else:
-                if key == "email":
+                # only admins can add/remove other admins
+                if key == "is_admin":
+                    if not current_user.is_admin:
+                        return forbidden_error(
+                            f"{current_user} forbidden from assigning admin status"
+                        )
+                elif key == "email":
                     current_app.logger.warning(
                         "%s is modifying %s email, from %s to %s",
                         current_user,

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -144,6 +144,7 @@ class TestUserResource:
             (1, 2, {"name": "NEW_NAME2"}),
             (1, 3, {"email": "name3@example.net"}),
             (1, 4, {"name": "NEW_NAME4", "email": "name4@example.net"}),
+            (1, 2, {"is_admin": True}),
         ],
     )
     def test_put(self, current_user_id, user_id, data, app, client, db_session):
@@ -165,6 +166,7 @@ class TestUserResource:
         [
             (3, 2, {"name": "NEW_NAME2"}, 403),
             (1, 999, {"name": "NEW_NAME999"}, 404),
+            (2, 2, {"is_admin": True}, 403),
             # TODO: figure out if there's a way to throw nice errors
             # in case "current user" doesn't actually exist
             # (999, 999, {"name": "NEW_NAME999"}, 404),


### PR DESCRIPTION
## changes

only allow admin users to set the `user.is_admin` attribute, especially so that a non-admin user couldn't self-assign admin status

## context

https://app.asana.com/0/1206730431337718/1209857083773507/f

## questions

- what's the envisioned workflow for assign the "first" admin user(s)?