### PR TITLE
get all admin users via api call

### DIFF
--- a/colandr/apis/resources/users.py
+++ b/colandr/apis/resources/users.py
@@ -160,6 +160,11 @@ class UsersResource(Resource):
                 "type": "integer",
                 "description": "unique review id on which users are collaborators",
             },
+            "admins": {
+                "in": "query",
+                "type": "boolean",
+                "description": "if True, get all admin users in the system",
+            },
         },
         responses={
             200: "successfully got user record(s)",
@@ -173,11 +178,12 @@ class UsersResource(Resource):
             "review_id": ma_fields.Int(
                 load_default=None, validate=Range(min=1, max=constants.MAX_INT)
             ),
+            "admins": ma_fields.Boolean(load_default=None),
         },
         location="query",
     )
     @jwtext.jwt_required()
-    def get(self, email, review_id):
+    def get(self, email, review_id, admins):
         """get user record(s) for one or more matching users"""
         current_user = jwtext.get_current_user()
         if email:
@@ -206,6 +212,15 @@ class UsersResource(Resource):
                     f"{current_user} forbidden to see users for this review"
                 )
             return UserSchema(many=True).dump(review.users)
+        elif admins:
+            if not current_user.is_admin:
+                return forbidden_error(
+                    f"{current_user} must be an admin to get all admins"
+                )
+            admins = db.session.execute(
+                sa.select(models.User).filter_by(is_admin=True)
+            ).scalars()
+            return UserSchema(many=True).dump(admins)
 
     @ns.doc(
         expect=(user_model, "user data to be created"),

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -186,17 +186,18 @@ class TestUserResource:
 @pytest.mark.usefixtures("db_session")
 class TestUsersResource:
     @pytest.mark.parametrize(
-        ["email", "review_id", "user_ids"],
+        ["email", "review_id", "admins", "user_ids"],
         [
-            ("name1@example.com", None, 1),
-            ("name2@example.com", 1, 2),
-            (None, 1, [1, 2, 3]),
+            ("name1@example.com", None, None, 1),
+            ("name2@example.com", 1, None, 2),
+            (None, 1, None, [1, 2, 3]),
+            (None, None, True, [1]),
         ],
     )
-    def test_get(self, email, review_id, user_ids, app, client, admin_headers):
+    def test_get(self, email, review_id, admins, user_ids, app, client, admin_headers):
         with app.test_request_context():
             url = flask.url_for(
-                "users_users_resource", email=email, review_id=review_id
+                "users_users_resource", email=email, review_id=review_id, admins=admins
             )
         response = client.get(url, headers=admin_headers)
         assert response.status_code == 200
@@ -209,21 +210,33 @@ class TestUsersResource:
         elif review_id is not None:
             assert isinstance(data, list)
             assert [user["id"] for user in data] == user_ids
+        elif admins is not None:
+            assert isinstance(data, list)
+            assert [user["id"] for user in data] == user_ids
 
     @pytest.mark.parametrize(
-        ["current_user_id", "email", "review_id", "status_code"],
+        ["current_user_id", "email", "review_id", "admins", "status_code"],
         [
-            (1, "name999@example.com", None, 404),
-            (1, None, 999, 404),
-            (4, None, 1, 403),
+            (1, "name999@example.com", None, None, 404),
+            (1, None, 999, None, 404),
+            (4, None, 1, None, 403),
+            (2, None, None, True, 403),
         ],
     )
     def test_get_errors(
-        self, current_user_id, email, review_id, status_code, app, client, db_session
+        self,
+        current_user_id,
+        email,
+        review_id,
+        admins,
+        status_code,
+        app,
+        client,
+        db_session,
     ):
         with app.test_request_context():
             url = flask.url_for(
-                "users_users_resource", email=email, review_id=review_id
+                "users_users_resource", email=email, review_id=review_id, admins=admins
             )
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:


### PR DESCRIPTION
## changes

adds `admins` param to `GET /users` endpoint, so that an admin user can get a list of all other admins

## context

https://app.asana.com/0/1206730431337718/1209857083773504/f

## questions

- this approach feels a bit clunky, though it seemed like the simplest implementation. are you okay with the `admins` param on GET users?
- do we want the `admins` param to be separate from `review_id`, or do we need those to interact for, e.g. all admins associated with a given review?