### PR TITLE
fix: ris import no longer fail on missing dttm col

### DIFF
--- a/colandr/lib/fileio/ris.py
+++ b/colandr/lib/fileio/ris.py
@@ -3,6 +3,7 @@ References:
     - https://github.com/asreview/citation-file-formatting/tree/main
     - https://en.wikipedia.org/wiki/RIS_(file_format)
 """
+
 import logging
 import pathlib
 import typing as t
@@ -151,7 +152,7 @@ def _sanitize_reference(reference: dict) -> dict:
         {
             key: reference[key].strftime("%Y-%m-%d")
             for key in DTTM_KEYS
-            if key in reference
+            if reference.get(key)
         }
     )
     return reference

--- a/colandr/lib/fileio/ris.py
+++ b/colandr/lib/fileio/ris.py
@@ -143,7 +143,7 @@ def _sanitize_reference(reference: dict) -> dict:
     if "notes" in reference:
         reference["notes"] = _strip_tags_from_notes(reference["notes"])
     # split date key into year (if needed) and month
-    if "date" in reference:
+    if reference.get("date"):
         reference["pub_month"] = reference["date"].month
         if "pub_year" not in reference:
             reference["pub_year"] = reference["date"].year


### PR DESCRIPTION
## changes

fixes record parsing logic that assumed certain dt/dttm columns in RIS files are present and non-null

**TODO:** revisit parsing code more holistically

## context

https://app.asana.com/1/6325821815997/project/1207781048453811/task/1209912102585846?focus=true