### PR TITLE
Ported Pdfestrian CLI scripts for DB population

### DIFF
--- a/scripts/map_aid_to_study.py
+++ b/scripts/map_aid_to_study.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""
+A Python script to map AidSeq indices to study IDs
+by matching citation titles in the studies.citation JSONB column.
+
+Usage:
+python scripts/map_aid_to_study.py -a <aids_file> -o <id_map_file> \
+    --db-host <host> --db-port <port> --db-name <db> --db-user <user> --db-password <password>
+
+Example:
+python scripts/map_aid_to_study.py -a pdfestrian/json/aidSeq.json -o pdfestrian/json/id_map.tsv \
+    --db-host localhost --db-port 5432 --db-name colandr --db-user colandr --db-password thepassword
+"""
+import argparse
+import json
+import logging
+import sys
+
+import psycopg
+
+
+def add_and_parse_args() -> argparse.Namespace:
+    """Parse args"""
+    parser = argparse.ArgumentParser(
+        description="Map AidSeq indices to study IDs by matching citation titles."
+    )
+    parser.add_argument("-a", "--aids", required=True, type=str,
+                        help="Path to the AidSeq JSON Lines file (required)")
+    parser.add_argument("-o", "--out", required=True, type=str,
+                        help="Path to the idMap.tsv output file (required)")
+    parser.add_argument("--db-host", required=True, type=str,
+                        help="Database host")
+    parser.add_argument("--db-port", required=False, type=int, default=5432,
+                        help="Database port (default: 5432)")
+    parser.add_argument("--db-name", required=True, type=str,
+                        help="Database name")
+    parser.add_argument("--db-user", required=True, type=str,
+                        help="Database user")
+    parser.add_argument("--db-password", required=True, type=str,
+                        help="Database password")
+    return parser.parse_args()
+
+
+def load_aidseq(filepath: str) -> list[dict]:
+    """
+    Load AidSeq data from a JSON Lines file. Each line is a separate JSON object.
+    """
+    result = []
+    try:
+        with open(filepath, 'r') as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                result.append(json.loads(line))
+        return result
+    except Exception as e:
+        logging.error("Error loading AidSeq data from %s: %s", filepath, e)
+        return []
+
+
+def get_study_id_by_title(conn: psycopg.Connection, title: str) -> int | None:
+    """
+    Query the studies table for a study with a citation title matching the given title.
+    Returns the study ID if found, else None.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id FROM studies
+            WHERE citation->>'title' = %s
+            LIMIT 1
+            """,
+            (title,)
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def main():
+    """Main script method"""
+    args = add_and_parse_args()
+
+    aids = load_aidseq(args.aids)
+
+    conn = psycopg.connect(
+        host=args.db_host,
+        port=args.db_port,
+        dbname=args.db_name,
+        user=args.db_user,
+        password=args.db_password
+    )
+
+    aid_to_study_id = {}
+    found = 0
+    try:
+        for aid in aids:
+            aid_index = aid.get("index")
+            all_fields = aid.get("allFields", {})
+            title = all_fields.get("Title")
+            if not title:
+                continue
+            study_id = get_study_id_by_title(conn, title)
+            if study_id is not None:
+                aid_to_study_id[aid_index] = study_id
+                found += 1
+        print(f"Found {found} out of {len(aids)} citations")
+
+        with open(args.out, "w") as f:
+            for aid_index, study_id in aid_to_study_id.items():
+                f.write(f"{aid_index}\t{study_id}\n")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/map_aid_to_study.py
+++ b/scripts/map_aid_to_study.py
@@ -12,6 +12,7 @@ python scripts/map_aid_to_study.py -a pdfestrian/json/aidSeq.json -o pdfestrian/
     --db-host localhost --db-port 5432 --db-name colandr --db-user colandr --db-password thepassword
 """
 import argparse
+import csv
 import json
 import logging
 import sys
@@ -68,6 +69,7 @@ def get_study_id_by_title(conn: psycopg.Connection, title: str) -> int | None:
             """
             SELECT id FROM studies
             WHERE citation->>'title' = %s
+            AND dedupe_status='not_duplicate'
             LIMIT 1
             """,
             (title,)
@@ -105,9 +107,10 @@ def main():
                 found += 1
         print(f"Found {found} out of {len(aids)} citations")
 
-        with open(args.out, "w") as f:
+        with open(args.out, "w", newline="") as f:
+            writer = csv.writer(f, delimiter="\t")
             for aid_index, study_id in aid_to_study_id.items():
-                f.write(f"{aid_index}\t{study_id}\n")
+                writer.writerow([aid_index, study_id])
     finally:
         conn.close()
 

--- a/scripts/populate_full_texts.py
+++ b/scripts/populate_full_texts.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""
+A Python script to bulk upload PDFs to the Colandr API,
+mapping PDF files to study records using AidSeq and idMap files.
+
+Usage:
+python scripts/populate_full_texts.py -a <aids_file> -i <id_map_file> \
+    -f <fulltextids_file> -d <pdf_dir> -t <auth_token> [--host <host>]
+
+Example:
+python scripts/populate_full_texts.py -a pdfestrian/json/aidSeq.json -i pdfestrian/json/id_map.tsv \
+    -f pdfestrian/json/fulltextids.txt -d /path/to/pdfs -t YOUR_AUTH_TOKEN
+"""
+import argparse
+import json
+import logging
+import os
+import sys
+
+import requests
+
+
+def add_and_parse_args() -> argparse.Namespace:
+    """Parse command line args"""
+    parser = argparse.ArgumentParser(
+        description="Bulk upload PDFs to Colandr API, mapping PDF files to study records."
+    )
+    parser.add_argument("-a", "--aids", required=True, type=str,
+                        help="Path to the AidSeq JSON Lines file (required)")
+    parser.add_argument("-i", "--idMap", required=True, type=str,
+                        help="Path to the idMap.tsv file (required)")
+    parser.add_argument("-f", "--fulltextids", required=True, type=str,
+                        help="Path to the fulltextids file (required)")
+    parser.add_argument("-d", "--pdfdir", required=True, type=str,
+                        help="Directory containing PDF files to upload (required)")
+    parser.add_argument("-t", "--token", required=True, type=str,
+                        help="Authentication token for API access (required)")
+    parser.add_argument("--host", type=str, default="http://localhost:5000",
+                        help="Host name of the API (default: http://localhost:5000)")
+    return parser.parse_args()
+
+
+def load_aidseq(filepath: str) -> list[dict]:
+    """
+    Load AidSeq data from a JSON Lines file.
+    Each line is a separate JSON object.
+
+    Args:
+        filepath: Path to the JSON Lines file
+
+    Returns:
+        List of dictionaries containing AidSeq data
+    """
+    result = []
+    try:
+        with open(filepath, 'r') as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                result.append(json.loads(line))
+        return result
+    except Exception as e:
+        logging.error("Error loading AidSeq data from %s: %s", filepath, e)
+        return []
+
+
+def parse_id_map(filepath: str) -> dict[str, str]:
+    """
+    Parse file with aid index to study id map
+    """
+    id_map = {}
+    with open(filepath, 'r') as f:
+        for line in f:
+            parts = line.strip().split('\t')
+            if len(parts) >= 2:
+                id_map[parts[0]] = parts[1]
+    return id_map
+
+
+def load_fulltext_ids(filepath: str) -> list[str]:
+    """
+    Parse file with fulltext ids that need to be processed
+    """
+    with open(filepath, 'r') as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def put_pdf(record_id: int, filename: str, pdf_dir: str, host: str, token: str) -> bool:
+    """
+    Upload PDF file using Colandr API
+    """
+    pdf_path = os.path.join(pdf_dir, filename + ".pdf")
+    if not os.path.isfile(pdf_path):
+        logging.warning("PDF file not found: %s", pdf_path)
+        return False
+    with open(pdf_path, "rb") as pdf_file:
+        response = requests.post(
+            f"{host}/api/fulltexts/{record_id}/upload",
+            files={"uploaded_file": (filename + ".pdf", pdf_file, "application/pdf")},
+            headers={"Authorization": f"Bearer {token}"}
+        )
+        if not response.ok:
+            logging.error("Failed to upload PDF for record %s: %s", record_id, response.text)
+            return False
+        try:
+            data = response.json()
+            return bool(data.get("extracted_items"))
+        except Exception:
+            return response.ok
+
+
+def main():
+    """Main script method"""
+    args = add_and_parse_args()
+
+    aids = load_aidseq(args.aids)
+    id_map = parse_id_map(args.idMap)
+    rev_id_map = {v: k for k, v in id_map.items()}
+    fulltext_ids = load_fulltext_ids(args.fulltextids)
+
+    aidseq_by_index = {str(aid.get("index")): aid for aid in aids}
+
+    for record_id in fulltext_ids:
+        aid_index = rev_id_map.get(record_id)
+        if not aid_index:
+            logging.warning("No AidSeq index found for record ID %s", record_id)
+            continue
+        aid = aidseq_by_index.get(aid_index)
+        if not aid:
+            logging.warning("No AidSeq record found for index %s", aid_index)
+            continue
+        pdf_info = aid.get("pdf", {})
+        filename = pdf_info.get("filename")
+        if not filename:
+            logging.warning("No PDF filename found for AidSeq index %s", aid_index)
+            continue
+        put_pdf(int(record_id), filename, args.pdfdir, args.host, args.token)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/populate_full_texts.py
+++ b/scripts/populate_full_texts.py
@@ -12,6 +12,7 @@ python scripts/populate_full_texts.py -a pdfestrian/json/aidSeq.json -i pdfestri
     -f pdfestrian/json/fulltextids.txt -d /path/to/pdfs -t YOUR_AUTH_TOKEN
 """
 import argparse
+import csv
 import json
 import logging
 import os
@@ -69,11 +70,11 @@ def parse_id_map(filepath: str) -> dict[str, str]:
     Parse file with aid index to study id map
     """
     id_map = {}
-    with open(filepath, 'r') as f:
-        for line in f:
-            parts = line.strip().split('\t')
-            if len(parts) >= 2:
-                id_map[parts[0]] = parts[1]
+    with open(filepath, 'r', newline='') as f:
+        reader = csv.reader(f, delimiter='\t')
+        for row in reader:
+            if len(row) >= 2:
+                id_map[row[0]] = row[1]
     return id_map
 
 

--- a/scripts/populate_labels.py
+++ b/scripts/populate_labels.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+"""
+A Python script to populate labels for documents in the database using AidSeq data.
+
+Usage:
+python scripts/populate_labels.py -a <aids_file> -i <id_map_file> -t <auth_token> [--host <host>]
+
+Example:
+python scripts/populate_labels.py -a pdfestrian/json/aidSeq.json -i pdfestrian/json/idMap.tsv -t AT
+"""
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+
+import requests
+
+
+@dataclass
+class Label:
+    """Label definition"""
+    label: str
+    value: list[str]
+
+
+biome_map: dict[str, str] = {
+    "T_T": "Tundra",
+    "T_TSTMBF": "Forest",
+    "T_TSTGSS": "Grasslands",
+    "T_TSTDBF": "Forest",
+    "T_TSTCF": "Forest",
+    "T_TGSS": "Grasslands",
+    "T_TCF": "Forest",
+    "T_TBMF": "Forest",
+    "T_MGS": "Grasslands",
+    "T_MFWS": "Forest",
+    "T_M": "Mangrove",
+    "T_FGS": "Grasslands",
+    "T_DXS": "Desert",
+    "T_BFT": "Forest",
+    "M_TU": "Marine",
+    "M_TSTSS": "Marine",
+    "M_TSS": "Marine",
+    "M_TRU": "Marine",
+    "M_TRC": "Marine",
+    "FW_XFEB": "Freshwater",
+    "FW_TSTUR": "Freshwater",
+    "FW_TSTFRW": "Freshwater",
+    "FW_TSTCR": "Freshwater",
+    "FW_TCR": "Freshwater",
+    "FW_MF": "Freshwater",
+    "FW_LRD": "Freshwater",
+    "FW_LL": "Freshwater",
+    "FW_TFRW": "Freshwater",
+    "FW_TUR": "Freshwater"
+}
+
+interv_map: dict[str, str] = {
+    "area_mgmt": "area management",
+    "area_protect": "area protection",
+    "sub": "substitution",
+    "training": "training",
+    "restoration": "restoration",
+    "sus_use": "sustainable use",
+    "legis": "legislation",
+    "form_ed": "formal education",
+    "aware_comm": "awareness and communications",
+    "compl_enfor": "compliance and enforcement",
+    "inst_civ_dev": "institutional and civil society development",
+    "market": "market forces",
+    "non_mon": "non-monetary values",
+    "other": "other",
+    "pol_reg": "policies and regulations",
+    "priv_codes": "private sector standards and codes",
+    "sp_control": "species control",
+    "sp_mgmt": "species management",
+    "sp_recov": "species recovery",
+    "sp_reint": "species re-introduction",
+    "cons_fin": "conservation finance",
+    "part_dev": "partnership and alliance development",
+    "liv_alt": "enterprises and livelihood alternatives",
+    "res_mgmt": "resource protection and management"
+}
+
+outcome_map: dict[str, str] = {
+    "free_choice": "freedom of choice/action",
+    "other": "other",
+    "culture": "cultural and spiritual",
+    "health": "health",
+    "eco_liv_std": "economic living standards",
+    "mat_liv_std": "material living standards",
+    "sec_saf": "security and safety",
+    "sub_well": "subjective well-being",
+    "education": "education",
+    "soc_rel": "social relations",
+    "env": "environment",
+    "gov": "governance and empowerment",
+    "NA": "other"
+}
+
+
+def add_and_parse_args() -> argparse.Namespace:
+    """Parse command line args"""
+    parser = argparse.ArgumentParser(
+        description="Populate labels for documents in the database using AidSeq data"
+    )
+    parser.add_argument("-a", "--aids", required=True, type=str,
+                        help="Path to the AidSeq JSON Lines file (required)")
+    parser.add_argument("-i", "--idMap", required=True, type=str,
+                        help="Path to the idMap file that maps AidSeq indices to DB IDs (required)")
+    parser.add_argument("-t", "--token", required=True, type=str,
+                        help="Authentication token for API access (required)")
+    parser.add_argument("--host", type=str, default="http://localhost:5000",
+                        help="Host name of the API (default: http://localhost:5000)")
+    return parser.parse_args()
+
+
+def put_labels(id: int, labels: list[Label], host: str, token: str) -> bool:
+    """Put labels to the API endpoint for a specific ID using Bearer token authentication"""
+    try:
+        labels_dict = [{"label": label.label, "value": label.value} for label in labels]
+
+        response = requests.put(
+            f"{host}/api/data_extractions/{id}",
+            json=labels_dict,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}"
+            }
+        )
+        response.raise_for_status()
+        data = response.json()
+        return len(data.get("extracted_items", [])) > 0
+    except Exception as e:
+        logging.error("Error putting labels for ID %s: %s", id, e)
+        return False
+
+
+def to_labels(label: str, labels: list[str]) -> list[Label]:
+    """Convert list of label values to Label objects"""
+    if labels:
+        return [Label(label=label, value=labels)]
+    return []
+
+
+def parse_id_map(filepath: str) -> dict[str, str]:
+    """Parse ID map file that maps AidSeq indices to API IDs"""
+    id_map = {}
+    with open(filepath, 'r') as f:
+        for line in f:
+            parts = line.strip().split('\t')
+            if len(parts) >= 2:
+                id_map[parts[0]] = parts[1]
+    return id_map
+
+
+def load_aidseq(filepath: str) -> list[dict]:
+    """
+    Load AidSeq data from a JSON Lines file.
+    Each line is a separate JSON object.
+
+    Args:
+        filepath: Path to the JSON Lines file
+
+    Returns:
+        List of dictionaries containing AidSeq data
+    """
+    result = []
+    try:
+        with open(filepath, 'r') as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                result.append(json.loads(line))
+        return result
+    except Exception as e:
+        logging.error("Error loading AidSeq data from %s: %s", filepath, e)
+        return []
+
+
+def main():
+    """Main script method"""
+    args = add_and_parse_args()
+
+    aids = load_aidseq(args.aids)
+    id_map = parse_id_map(args.idMap)
+
+    lbm = {"grasslands": "grassland"}
+
+    successful = []
+
+    for aid in aids:
+        aid_index = str(aid.get("index", 0))
+        if aid_index in id_map:
+            id_val = id_map[aid_index]
+
+            biomes = []
+            for biome_data in aid.get("biome", []):
+                if isinstance(biome_data, dict) and "biome" in biome_data:
+                    biome = biome_data["biome"]
+                    biome = biome_map.get(biome, biome).lower()
+                    biome = lbm.get(biome, biome)
+                    biomes.append(biome)
+            biomes = list(set(biomes))
+
+            intervs = []
+            for interv_data in aid.get("interv", []):
+                if isinstance(interv_data, dict) and "Int_type" in interv_data:
+                    interv = interv_map.get(interv_data["Int_type"], "other")
+                    intervs.append(interv)
+            intervs = list(set(intervs))
+
+            outcomes = []
+            for outcome_data in aid.get("outcome", []):
+                if isinstance(outcome_data, dict) and "Outcome" in outcome_data:
+                    outcome = outcome_map.get(outcome_data["Outcome"], "other")
+                    outcomes.append(outcome)
+            outcomes = list(set(outcomes))
+
+            labels = (to_labels("biome", biomes) +
+                     to_labels("intervention_type", intervs) +
+                     to_labels("outcome_type", outcomes))
+
+            if put_labels(int(id_val), labels, args.host, args.token):
+                successful.append(int(id_val))
+                print(f"Added for {id_val}")
+            else:
+                print(f"Failed for {id_val}")
+
+    print(", ".join(map(str, successful)))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/populate_labels.py
+++ b/scripts/populate_labels.py
@@ -9,6 +9,7 @@ Example:
 python scripts/populate_labels.py -a pdfestrian/json/aidSeq.json -i pdfestrian/json/idMap.tsv -t AT
 """
 import argparse
+import csv
 import json
 import logging
 import sys
@@ -147,11 +148,11 @@ def to_labels(label: str, labels: list[str]) -> list[Label]:
 def parse_id_map(filepath: str) -> dict[str, str]:
     """Parse ID map file that maps AidSeq indices to API IDs"""
     id_map = {}
-    with open(filepath, 'r') as f:
-        for line in f:
-            parts = line.strip().split('\t')
-            if len(parts) >= 2:
-                id_map[parts[0]] = parts[1]
+    with open(filepath, 'r', newline='') as f:
+        reader = csv.reader(f, delimiter='\t')
+        for row in reader:
+            if len(row) >= 2:
+                id_map[row[0]] = row[1]
     return id_map
 
 


### PR DESCRIPTION
This is the port of [Pdfestrian CLI scripts](https://github.com/datakind/permanent-colandr-back/tree/develop/pdfestrian/src/main/scala/org/datakind/ci/pdfestrian/scripts) for DB population (fulltexts, data_extractions)

## changes
Ported `[FindDBIDs](https://github.com/datakind/permanent-colandr-back/blob/develop/pdfestrian/src/main/scala/org/datakind/ci/pdfestrian/scripts/FindDBIDs.scala), [PopulateFullTexts](https://github.com/datakind/permanent-colandr-back/blob/develop/pdfestrian/src/main/scala/org/datakind/ci/pdfestrian/scripts/PopulateFullTexts.scala) and [PopulateLabels](https://github.com/datakind/permanent-colandr-back/blob/develop/pdfestrian/src/main/scala/org/datakind/ci/pdfestrian/scripts/PopulateLabels.scala) scripts.

## context
These scripts may be useful for DB population with fulltexts from PDF files and data_extractions (labels for these fulltexts for ML) from `pdfestrian/json/aidSeq.json` file.

## questions

