### PR TITLE
fix issue with gcs fulltext uploads

### DIFF
--- a/colandr/apis/resources/fulltext_uploads.py
+++ b/colandr/apis/resources/fulltext_uploads.py
@@ -105,17 +105,8 @@ class FulltextUploadResource(Resource):
         if not filepath:
             return not_found_error(f"no uploaded file for <Study(id={id})> found")
 
-        # NOTE: this approach leaves behind a local copy of the fulltext file
-        # when the filesystem isn't local disk -- not great!
-        # the workaround below should work for any filesystem
-        # if current_app.config["FILESYSTEM_PROTOCOL"] == "file":
-        #     return send_file(filepath)
-        # else:
-        #     remote_filepath = filepath
-        #     local_filepath = os.path.join("/tmp", "colandr", filepath)
-        #     fs.get_file(remote_filepath, local_filepath)
-        #     return send_file(local_filepath)
-
+        # read file contents into memory as bytes, then wrap up in a file-like interface
+        # which flask's send_file can then pretend is a file on disk
         with fs.open(filepath, mode="rb") as f:
             file_contents = f.read()
         return send_file(
@@ -182,32 +173,16 @@ class FulltextUploadResource(Resource):
         # make review directory if doesn't already exist
         fs.makedirs(os.path.dirname(filepath), exist_ok=True)
         # save content to file on filesystem
-        if current_app.config["FILESYSTEM_PROTOCOL"] == "file":
-            uploaded_file.save(filepath)
-        else:
-            # HACK: save file temporarily to local disk (is this advisable??)
-            remote_filepath = filepath
-            local_filepath = os.path.join("/tmp", "colandr", remote_filepath)
-            uploaded_file.save(local_filepath)
-            fs.put_file(local_filepath, remote_filepath)
-            # below, we'll leverage the local file for io
-            filepath = local_filepath
+        text_content = uploaded_file.stream.read()
+        with fs.open(filepath, mode="wb") as f:
+            # uploaded_file.save(f) may also work well
+            f.write(text_content)
 
-        try:
-            # extract content from disk, depending on type
-            if ext == ".txt":
-                with io.open(filepath, mode="rb") as f:
-                    text_content = f.read()
-            elif ext == ".pdf":
-                text_content = fileio.pdf.read(filepath).encode("utf-8")
-            else:
-                raise ValueError(
-                    f"filepath '{filepath}' suffix '{ext} is not .txt or .pdf"
-                )
-        finally:
-            # remove uploaded file that was temporarily saved in a local dir
-            if current_app.config["FILESYSTEM_PROTOCOL"] != "file":
-                os.remove(local_filepath)  # type: ignore
+        # actually parse raw bytes in case of proper pdf file
+        if ext == ".pdf":
+            text_content = fileio.pdf.read(stream=io.BytesIO(text_content)).encode(
+                "utf-8"
+            )
 
         fulltext = {
             "filename": filename,

--- a/colandr/lib/fileio/pdf.py
+++ b/colandr/lib/fileio/pdf.py
@@ -1,18 +1,26 @@
+import io
 import pathlib
+import typing as t
 
 import pymupdf
 
 
-def read(file_path: str | pathlib.Path, *, redact_tables: bool = False) -> str:
+def read(
+    *,
+    file_path: t.Optional[str | pathlib.Path] = None,
+    stream: t.Optional[bytes | io.BytesIO] = None,
+    redact_tables: bool = False,
+) -> str:
     """
     Extract text from a PDF file, optionally redacting tables so they're not included.
 
     Args:
         file_path
+        stream
         redact_tables
     """
     page_texts = []
-    with pymupdf.open(str(file_path), filetype="pdf") as doc:
+    with pymupdf.open(filename=file_path, stream=stream, filetype="pdf") as doc:
         for page in doc.pages():
             # assert isinstance(page, pymupdf.Page)  # type guard
             if redact_tables:

--- a/tests/lib/fileio/test_pdf.py
+++ b/tests/lib/fileio/test_pdf.py
@@ -67,7 +67,7 @@ class TestPdfFile:
             request.config.rootpath / "tests" / "fixtures" / "fulltexts"
         )
         file_path = fixtures_dir / file_name
-        fulltext = pdf.read(file_path, redact_tables=redact_tables)
+        fulltext = pdf.read(file_path=file_path, redact_tables=redact_tables)
         assert fulltext and isinstance(fulltext, str)
         for snippet in included_snippets:
             assert snippet in fulltext


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- allows reading pdf files from path or stream
- streamlines fulltext uploads to avoid unnecessary / redundant file i/o logic (the bug was here)

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

there was a bug in PR  #150, but only for non-"file" protocols -- which isn't currently tested locally

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
