### PR TITLE
compute total num studies on prisma export

### DIFF
--- a/colandr/apis/resources/review_exports.py
+++ b/colandr/apis/resources/review_exports.py
@@ -60,6 +60,7 @@ class ReviewExportPrismaResource(Resource):
             is None
         ):
             return forbidden_error(f"{current_user} forbidden to get this review")
+
         # get counts by step, i.e. prisma
         n_studies_by_source_stmt = (
             sa.select(
@@ -69,11 +70,11 @@ class ReviewExportPrismaResource(Resource):
             .filter(models.Import.review_id == id)
             .group_by(models.DataSource.source_type)
         )
-
         n_studies_by_source = {
             row.source_type: row.sum
             for row in db.session.execute(n_studies_by_source_stmt)
         }
+        n_studies = sum(n_studies_by_source.values())
 
         n_unique_studies = db.session.execute(
             sa.select(sa.func.count()).select_from(
@@ -131,6 +132,7 @@ class ReviewExportPrismaResource(Resource):
         current_app.logger.debug("prisma counts exported for %s", review)
 
         return {
+            "num_studies": n_studies,
             "num_studies_by_source": n_studies_by_source,
             "num_unique_studies": n_unique_studies,
             "num_screened_citations": n_citations_screened,

--- a/tests/api/test_review_exports.py
+++ b/tests/api/test_review_exports.py
@@ -12,6 +12,7 @@ class TestReviewExportPrismaResource:
             (
                 1,
                 {
+                    "num_studies": 3,
                     "num_studies_by_source": {"database": 2, "gray_literature": 1},
                     "num_unique_studies": 3,
                     "num_screened_citations": 3,
@@ -25,6 +26,7 @@ class TestReviewExportPrismaResource:
             (
                 2,
                 {
+                    "num_studies": 1,
                     "num_studies_by_source": {"database": 1},
                     "num_unique_studies": 1,
                     "num_screened_citations": 1,


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

add "num_studies" field to prisma export data

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://app.asana.com/1/6325821815997/project/1206730431337718/task/1210827614255717?focus=true

this number is showing up as null in the app. afaict the logic was unchanged from v1.0, so i'd guess that the new front-end is doing something different from before. adding this field to the back-end is better, and should make things easier in the front-end.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
