### PR TITLE
actually forbid changes to frozen reviews

### DIFF
--- a/colandr/apis/resources/citation_imports.py
+++ b/colandr/apis/resources/citation_imports.py
@@ -170,7 +170,7 @@ class CitationsImportsResource(Resource):
                 current_user.review_user_assoc.select().filter_by(review_id=review_id)
             ).one_or_none()
             is None
-        ):
+        ) or review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to add citations to this review"
             )

--- a/colandr/apis/resources/citation_screenings.py
+++ b/colandr/apis/resources/citation_screenings.py
@@ -112,7 +112,7 @@ class CitationScreeningsResource(Resource):
         study = db.session.get(models.Study, id)
         if not study:
             return not_found_error(f"<Study(id={id})> not found")
-        if not _is_allowed(current_user, study.review_id):
+        if not _is_allowed(current_user, study.review_id, not_if_frozen=True):
             return forbidden_error(
                 f"{current_user} forbidden to delete citation screening for this review"
             )
@@ -157,7 +157,7 @@ class CitationScreeningsResource(Resource):
         study = db.session.get(models.Study, id)
         if not study:
             return not_found_error(f"<Study(id={id})> not found")
-        if not _is_allowed(current_user, study.review_id):
+        if not _is_allowed(current_user, study.review_id, not_if_frozen=True):
             return forbidden_error(
                 f"{current_user} forbidden to screen citations for this review"
             )
@@ -474,15 +474,20 @@ def _convert_screening_v2_into_v1(record) -> dict:
     return record
 
 
-def _is_allowed(current_user: models.User, review_id: int) -> bool:
-    is_allowed = current_user.is_admin
+def _is_allowed(
+    current_user: models.User, review_id: int, not_if_frozen: bool = False
+) -> bool:
     is_allowed = (
-        is_allowed
+        current_user.is_admin is True
         or db.session.execute(
             sa.select(models.ReviewUserAssoc).filter_by(
                 user_id=current_user.id, review_id=review_id
             )
         ).scalar_one_or_none()
         is not None
+    )
+    is_allowed &= (
+        not_if_frozen is False
+        or db.session.get(models.Review, review_id).status != "frozen"  # type: ignore
     )
     return is_allowed

--- a/colandr/apis/resources/citations.py
+++ b/colandr/apis/resources/citations.py
@@ -103,7 +103,7 @@ class CitationResource(Resource):
                 user_id=current_user.id
             ).one_or_none()
             is None
-        ):
+        ) or study.review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to delete this study.citation"
             )
@@ -149,7 +149,7 @@ class CitationResource(Resource):
                 user_id=current_user.id
             ).one_or_none()
             is None
-        ):
+        ) or study.review.status == "frozen":
             return forbidden_error(f"{current_user} forbidden to modify this study")
         citation = study.citation | {k: v for k, v in args.items() if k is not missing}
         study.citation = citation
@@ -237,7 +237,7 @@ class CitationsResource(Resource):
                 current_user.review_user_assoc.select().filter_by(review_id=review_id)
             ).one_or_none()
             is None
-        ):
+        ) or review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to add citations to this review"
             )

--- a/colandr/apis/resources/data_extractions.py
+++ b/colandr/apis/resources/data_extractions.py
@@ -113,13 +113,14 @@ class DataExtractionResource(Resource):
         if not extracted_data:
             return not_found_error(f"<DataExtraction(study_id={id})> not found")
         if (
-            db.session.execute(
+            current_user.is_admin is False
+            and db.session.execute(
                 current_user.review_user_assoc.select().filter_by(
                     review_id=extracted_data.review_id
                 )
             ).one_or_none()
             is None
-        ):
+        ) or extracted_data.review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to get extracted data for this study"
             )
@@ -169,11 +170,12 @@ class DataExtractionResource(Resource):
             return not_found_error(f"<DataExtraction(study_id={id})> not found")
         review_id = extracted_data.review_id
         if (
-            db.session.execute(
+            current_user.is_admin is False
+            and db.session.execute(
                 current_user.review_user_assoc.select().filter_by(review_id=review_id)
             ).one_or_none()
             is None
-        ):
+        ) or extracted_data.review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to modify extracted data for this study"
             )

--- a/colandr/apis/resources/deduplicate_studies.py
+++ b/colandr/apis/resources/deduplicate_studies.py
@@ -59,7 +59,7 @@ class DeduplicateStudiesResource(Resource):
                 user_id=current_user.id
             ).one_or_none()
             is None
-        ):
+        ) or review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to dedupe studies for this review"
             )

--- a/colandr/apis/resources/fulltext_screenings.py
+++ b/colandr/apis/resources/fulltext_screenings.py
@@ -121,7 +121,7 @@ class FulltextScreeningsResource(Resource):
                 )
             ).one_or_none()
             is None
-        ):
+        ) or study.review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to delete fulltext screening for this review"
             )
@@ -173,7 +173,7 @@ class FulltextScreeningsResource(Resource):
                 )
             ).one_or_none()
             is None
-        ):
+        ) or study.review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to screen fulltexts for this review"
             )

--- a/colandr/apis/resources/fulltext_uploads.py
+++ b/colandr/apis/resources/fulltext_uploads.py
@@ -154,7 +154,7 @@ class FulltextUploadResource(Resource):
                 )
             ).one_or_none()
             is None
-        ):
+        ) or study.review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to upload fulltext files to this review"
             )
@@ -234,7 +234,7 @@ class FulltextUploadResource(Resource):
                 )
             ).one_or_none()
             is None
-        ):
+        ) or study.review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to upload fulltext files to this review"
             )

--- a/colandr/apis/resources/fulltexts.py
+++ b/colandr/apis/resources/fulltexts.py
@@ -98,7 +98,7 @@ class FulltextResource(Resource):
                 user_id=current_user.id
             ).one_or_none()
             is None
-        ):
+        ) or study.review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to delete this study.fulltext"
             )

--- a/colandr/apis/resources/review_plans.py
+++ b/colandr/apis/resources/review_plans.py
@@ -111,7 +111,9 @@ class ReviewPlanResource(Resource):
         review = db.session.get(models.Review, id)
         if not review:
             return not_found_error(f"<Review(id={id})> not found")
-        if current_user.is_admin is False and current_user not in review.owners:
+        if (
+            current_user.is_admin is False and current_user not in review.owners
+        ) or review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to delete this review plan"
             )
@@ -180,7 +182,9 @@ class ReviewPlanResource(Resource):
         review = db.session.get(models.Review, id)
         if not review:
             return not_found_error(f"<Review(id={id})> not found")
-        if current_user.is_admin is False and current_user not in review.owners:
+        if (
+            current_user.is_admin is False and current_user not in review.owners
+        ) or review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to create this review plan"
             )

--- a/colandr/apis/resources/review_teams.py
+++ b/colandr/apis/resources/review_teams.py
@@ -145,7 +145,9 @@ class ReviewTeamResource(Resource):
         review = db.session.get(models.Review, id)
         if not review:
             return not_found_error(f"<Review(id={id})> not found")
-        if current_user.is_admin is False and current_user not in review.owners:
+        if (
+            current_user.is_admin is False and current_user not in review.owners
+        ) or review.status == "frozen":
             return forbidden_error(
                 f"{current_user} forbidden to modify this review team"
             )

--- a/colandr/apis/resources/studies.py
+++ b/colandr/apis/resources/studies.py
@@ -92,7 +92,7 @@ class StudyResource(Resource):
         study = db.session.get(models.Study, id)
         if not study:
             return not_found_error(f"<Study(id={id})> not found")
-        if not _is_allowed(current_user, study.review_id):
+        if not _is_allowed(current_user, study.review_id, not_if_frozen=True):
             return forbidden_error(f"{current_user} forbidden to delete this study")
         db.session.delete(study)
         db.session.commit()
@@ -123,7 +123,7 @@ class StudyResource(Resource):
         study = db.session.get(models.Study, id)
         if not study:
             return not_found_error(f"<Study(id={id})> not found")
-        if not _is_allowed(current_user, study.review_id):
+        if not _is_allowed(current_user, study.review_id, not_if_frozen=True):
             return forbidden_error(f"{current_user} forbidden to modify this study")
         for key, value in args.items():
             if key == "data_extraction_status":
@@ -511,15 +511,20 @@ class StudiesResource(Resource):
             )
 
 
-def _is_allowed(current_user: models.User, review_id: int) -> bool:
-    is_allowed = current_user.is_admin
+def _is_allowed(
+    current_user: models.User, review_id: int, not_if_frozen: bool = False
+) -> bool:
     is_allowed = (
-        is_allowed
+        current_user.is_admin is True
         or db.session.execute(
             sa.select(models.ReviewUserAssoc).filter_by(
                 user_id=current_user.id, review_id=review_id
             )
         ).scalar_one_or_none()
         is not None
+    )
+    is_allowed &= (
+        not_if_frozen is False
+        or db.session.get(models.Review, review_id).status != "frozen"  # type: ignore
     )
     return is_allowed


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds logic to forbid modifying (delete / put / post) data for a review if that review's status is "frozen" (all GET requests are still allowed, i.e. the review's data is read-only)

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://app.asana.com/1/6325821815997/project/1206730431337718/task/1206932431234340?focus=true

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- users are allowed to delete frozen reviews. does that seem reasonable?
- users are allowed to modify frozen reviews (just the review record), so that they can change the status away from "frozen" as needed. technically this allows modifying other attributes of the review. is this okay, or should i confine modifications of frozen reviews to only changing the status?