### PR TITLE
improve docker services' health-checks

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -34,6 +34,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ################
 FROM base AS dev
 
+# install curl, for use in this image's healthcheck
+RUN apt update && apt install -y curl && apt clean
+
 # copy built application from builder
 COPY --from=builder --chown=app:app /app /app
 
@@ -54,6 +57,9 @@ CMD ["flask", "--app", "colandr.app:create_app()", "run", "--host", "0.0.0.0", "
 
 #################
 FROM base AS prod
+
+# install curl, for use in this image's healthcheck
+RUN apt update && apt install -y curl && apt clean
 
 # copy built application from builder
 COPY --from=builder --chown=app:app /app /app

--- a/colandr/app.py
+++ b/colandr/app.py
@@ -37,7 +37,22 @@ def _configure_logging(app: flask.Flask) -> None:
     )
     handler.setLevel(app.config["LOG_LEVEL"])
     app.logger.addHandler(handler)
-    # app.logger.addFilter(logging.Filter("colandr"))
+
+    # filter logging for a particular endpoint
+    class EndpointFilter(logging.Filter):
+        def __init__(self, path: str, *args: t.Any, **kwargs: t.Any):
+            super().__init__(*args, **kwargs)
+            self._path = path
+
+        def filter(self, record: logging.LogRecord) -> bool:
+            return record.getMessage().find(self._path) == -1
+
+    werkzeug_logger = logging.getLogger("werkzeug")
+    werkzeug_logger.addFilter(EndpointFilter("/health"))
+    loggers = logging.root.manager.loggerDict
+    if "gunicorn.access" in loggers:
+        gunicorn_logger = logging.getLogger("gunicorn.access")
+        gunicorn_logger.addFilter(EndpointFilter("/health"))
 
 
 def _register_extensions(app: flask.Flask) -> None:

--- a/compose.yml
+++ b/compose.yml
@@ -114,6 +114,11 @@ services:
       - db
       - broker
     stop_signal: SIGINT
+    healthcheck:
+      test: ["CMD-SHELL", "celery", "--app=make_celery.celery_app", "inspect", "ping", "--destination celery@$$HOSTNAME"]
+      interval: "30s"
+      timeout: "10s"
+      retries: 3
     ports:
       - "8000:8000"
     env_file: ".env"

--- a/compose.yml
+++ b/compose.yml
@@ -77,10 +77,10 @@ services:
       - worker
     stop_signal: SIGINT
     healthcheck:
-      test: "curl localhost:5000/api/health"
-      interval: "10s"
-      timeout: "3s"
-      start_period: "5s"
+      test: ["CMD", "curl", "--fail", "--silent", "localhost:5000/api/health"]
+      interval: "30s"
+      timeout: "5s"
+      start_period: "15s"
       retries: 3
     ports:
       - 5001:5000

--- a/compose.yml
+++ b/compose.yml
@@ -103,8 +103,6 @@ services:
         # rebuild image if dependencies change in uv.lock
         - action: rebuild
           path: ./uv.lock
-    # volumes:
-    #   - .:/app
   worker:
     container_name: colandr-worker
     build:
@@ -136,8 +134,6 @@ services:
         # rebuild image if dependencies change in uv.lock
         - action: rebuild
           path: ./uv.lock
-    # volumes:
-    #   - .:/app
 
 networks:
   default:


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds `curl` to api container so the corresponding service's health check actually works
- adds log filtering to keep health check endpoint pings out of the logs (significantly reducing noise)
- adds a health check for the worker service too

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
