### PR TITLE
add endpoint to re-send confirm registration email (take 2)

### DIFF
--- a/colandr/api/v1/__init__.py
+++ b/colandr/api/v1/__init__.py
@@ -1,5 +1,6 @@
 import apiflask as af
 
+from . import authn, authz
 from .routes import (
     admin,
     auth,

--- a/colandr/api/v1/authn.py
+++ b/colandr/api/v1/authn.py
@@ -1,0 +1,133 @@
+import functools
+import typing as t
+
+import apiflask as af
+import flask_jwt_extended as jwtext
+import sqlalchemy as sa
+from flask import current_app
+
+from ... import models
+from ...extensions import db, jwt
+from . import errors
+
+
+# TODO: we should use redis for this
+# import celery
+# import redis.client
+# _JWT_BLOCKLIST = celery.current_app.backend.client  # type: ignore
+_JWT_BLOCKLIST = set()
+
+
+@jwt.user_identity_loader
+def user_identity_loader(user: models.User | str) -> str:
+    """
+    Callback function that takes the ``User`` passed in as the "identity"
+    when creating JWTs and returns it as a string, either as a stringified ``User.id``
+    or as the email associated with the user.
+    """
+    if isinstance(user, models.User):
+        user_identity = str(user.id)
+    elif isinstance(user, str):
+        user_identity = af.validators.Email()(user)  # validate as email
+    else:
+        raise ValueError(f"user={user} is invalid")
+    return user_identity
+
+
+@jwt.user_lookup_loader
+def user_lookup_callback(_jwt_header, jwt_data: dict) -> t.Optional[models.User]:
+    """
+    Callback function that loads a user from the database by its identity (id)
+    whenever a protected API route is accessed.
+    """
+    user_identity = jwt_data[current_app.config["JWT_IDENTITY_CLAIM"]]
+    if user_identity.isdigit():
+        user = db.session.get(models.User, int(user_identity))
+    elif isinstance(user_identity, str):
+        af.validators.Email()(user_identity)  # validate as email
+        user = db.session.execute(
+            sa.select(models.User).filter_by(email=user_identity)
+        ).scalar_one_or_none()
+    else:
+        raise ValueError(f"user identity={user_identity} is invalid")
+    return user
+
+
+@jwt.additional_claims_loader
+def additional_claims_loader(user: models.User | str) -> dict[str, object]:
+    """Callback function that adds additional claims to the JWT token."""
+    if isinstance(user, models.User):
+        return {"is_admin": user.is_admin}
+    else:
+        return {}
+
+
+@jwt.token_in_blocklist_loader
+def token_in_blocklist_loader(jwt_header, jwt_data: dict) -> bool:
+    """
+    Callback function that checks if a JWT is in the blocklist, i.e. has been revoked.
+    """
+    token = jwt_data["jti"]
+    # TODO: we should use redis for this
+    # token_in_blocklist = _JWT_BLOCKLIST.get(token)
+    token_in_blocklist = token in _JWT_BLOCKLIST
+    return token_in_blocklist
+
+
+def authenticate_user(email: str, password: str) -> models.User:
+    """
+    Verify that password matches the stored password for specified user email;
+    if credentials are valid, the corresponding user instance is returned.
+    """
+    user = db.session.execute(
+        sa.select(models.User).filter_by(email=email)
+    ).scalar_one_or_none()
+    if user is None or user.check_password(password) is False:
+        raise ValueError("invalid user email or password")
+    return user
+
+
+def get_user_from_token(token: str) -> t.Optional[models.User]:
+    """
+    Get a ``User`` from the identity stored in an encoded, unexpired JWT token,
+    if it exists in the database; otherwise, return None.
+    """
+    jwt_data = jwtext.decode_token(token, allow_expired=False)
+    identity = jwt_data[current_app.config["JWT_IDENTITY_CLAIM"]]
+    if identity.isdigit():
+        user = db.session.get(models.User, int(identity))
+    elif isinstance(identity, str):
+        af.validators.Email()(identity)  # validate as email
+        user = db.session.execute(
+            sa.select(models.User).filter_by(email=identity)
+        ).scalar_one_or_none()
+    else:
+        raise TypeError(f"user identity={identity} is invalid")
+    return user
+
+
+def pack_header_for_user(user) -> dict[str, str]:
+    """
+    Create an access token for ``user`` and pack it into a suitable header dict.
+    """
+    token = jwtext.create_access_token(identity=user, fresh=True)
+    header_key = f"{current_app.config['JWT_HEADER_TYPE']} {token}"
+    return {current_app.config["JWT_HEADER_NAME"]: header_key}
+
+
+def jwt_admin_required():
+    def wrapper(fn):
+        @functools.wraps(fn)
+        def decorator(*args, **kwargs):
+            jwtext.verify_jwt_in_request()
+            jwt_data = jwtext.get_jwt()
+            if jwt_data["is_admin"]:
+                return fn(*args, **kwargs)
+            else:
+                raise errors.ForbiddenError(
+                    message="this endpoint is for admin users only"
+                )
+
+        return decorator
+
+    return wrapper

--- a/colandr/api/v1/authz.py
+++ b/colandr/api/v1/authz.py
@@ -35,7 +35,9 @@ def user_is_allowed_for_review(
         .where(models.ReviewUserAssoc.user_role == sa.any_(pg.array(for_roles)))
     )
     return (
-        (
+        # only confirmed users are allowed
+        user.is_confirmed
+        and (
             # admin users are allowed
             user.is_admin is True
             # users associated with review having specified role(s) are allowed
@@ -60,14 +62,18 @@ def user_is_allowed_for_user(
         True if user is allowed to access user; False otherwise
     """
     return (
-        # current user same as user is allowed
-        user.id == user_id
-        # admin users are allowed
-        or user.is_admin is True
-        # users who are collaborators with specified user may be allowed
-        or (
-            if_collaborator is True
-            and any(collab.id == user_id for collab in user.collaborators)
+        # only confirmed users are allowed
+        user.is_confirmed
+        and (
+            # current user same as user is allowed
+            user.id == user_id
+            # admin users are allowed
+            or user.is_admin is True
+            # users who are collaborators with specified user may be allowed
+            or (
+                if_collaborator is True
+                and any(collab.id == user_id for collab in user.collaborators)
+            )
         )
     )
 

--- a/colandr/api/v1/routes/admin.py
+++ b/colandr/api/v1/routes/admin.py
@@ -9,8 +9,7 @@ from sqlalchemy.dialects import postgresql as pg
 from .... import models, tasks
 from ....extensions import db
 from ....utils import assign_status
-from .. import errors, schemas
-from . import auth
+from .. import authn, errors, schemas
 
 
 bp = af.APIBlueprint("admin", __name__, url_prefix="/admin")
@@ -27,7 +26,7 @@ bp = af.APIBlueprint("admin", __name__, url_prefix="/admin")
 )
 @bp.input(schemas.UserSchema, location="json")
 @bp.output(schemas.UserSchema)
-@auth.jwt_admin_required()
+@authn.jwt_admin_required()
 def post_users(json_data):
     current_user = jwtext.get_current_user()
     user = models.User(**json_data)
@@ -66,7 +65,7 @@ def post_users(json_data):
     location="query",
 )
 @bp.output(schemas.ReviewV2Schema(many=True))
-@auth.jwt_admin_required()
+@authn.jwt_admin_required()
 def get_reviews(query_data):
     review_ids = (
         [int(review_id) for review_id in query_data["review_ids"]]
@@ -138,7 +137,7 @@ def get_reviews(query_data):
     location="query",
 )
 @bp.output({}, 200)
-@auth.jwt_admin_required()
+@authn.jwt_admin_required()
 def post_citation_screenings(json_data, query_data):
     review_id = query_data["review_id"]
     user_id = query_data.get("user_id")
@@ -236,7 +235,7 @@ def post_citation_screenings(json_data, query_data):
     location="query",
 )
 @bp.output({}, 200)
-@auth.jwt_admin_required()
+@authn.jwt_admin_required()
 def post_fulltext_screenings(json_data, query_data):
     review_id = query_data["review_id"]
     user_id = query_data.get("user_id")

--- a/colandr/api/v1/routes/auth.py
+++ b/colandr/api/v1/routes/auth.py
@@ -150,6 +150,7 @@ class RegisterResendAPI(MethodView):
     @bp.doc(
         summary="re-send a registration confirmation email to an uncomfirmed user",
         responses={200: "successfully re-sent confirmation email"},
+        security="TokenAuth",
     )
     @bp.output({})
     @jwtext.jwt_required()

--- a/colandr/api/v1/routes/auth.py
+++ b/colandr/api/v1/routes/auth.py
@@ -64,9 +64,10 @@ class LoginAPI(MethodView):
                 message="no user found matching given email and password"
             )
         if not user.is_confirmed:
-            raise errors.UnauthorizedError(
-                message="user has been created but is not yet confirmed"
-            )
+            current_app.logger.warning("login by %s, who is not yet confirmed", user)
+            # raise errors.UnauthorizedError(
+            #     message="user has been created but is not yet confirmed"
+            # )
         access_token = jwtext.create_access_token(identity=user, fresh=True)
         refresh_token = jwtext.create_refresh_token(identity=user)
         current_app.logger.info("%s logged in", user)
@@ -149,22 +150,21 @@ class RegisterAPI(MethodView):
             )
 
         access_token = jwtext.create_access_token(identity=user, fresh=True)
-        confirm_url = url_for(
-            "auth.register_confirm", token=access_token, _external=True
-        )
-        if fe_app_site := current_app.config["FE_APP_SITE"]:
-            confirm_url = _replace_url_site(confirm_url, fe_app_site)
-
-        html = render_template(
-            "emails/user_registration.html", url=confirm_url, name=user.name
-        )
-        if current_app.config["MAIL_SERVER"]:
-            tasks.send_email.apply_async(
-                args=[[user.email], "Confirm your registration", "", html]
-            )
-            current_app.logger.info("registration email sent to %s", user.email)
-
+        _send_confirm_registration_email(user, access_token)
         return user
+
+
+class RegisterResendAPI(MethodView):
+    @bp.doc(
+        summary="re-send a registration confirmation email to an uncomfirmed user",
+        responses={200: "successfully re-sent confirmation email"},
+    )
+    @bp.output({})
+    @jwtext.jwt_required()
+    def post(self):
+        current_user = jwtext.get_current_user()
+        access_token = jwtext.create_access_token(identity=current_user, fresh=True)
+        _send_confirm_registration_email(current_user, access_token)
 
 
 class ConfirmRegistrationAPI(MethodView):
@@ -274,6 +274,9 @@ bp.add_url_rule("/login", view_func=LoginAPI.as_view("login"))
 bp.add_url_rule("/logout", view_func=LogoutAPI.as_view("logout"))
 bp.add_url_rule("/refresh", view_func=RefreshTokenAPI.as_view("refresh"))
 bp.add_url_rule("/register", view_func=RegisterAPI.as_view("register"))
+bp.add_url_rule(
+    "/register/resend", view_func=RegisterResendAPI.as_view("register_resend")
+)
 bp.add_url_rule(
     "/register/confirm", view_func=ConfirmRegistrationAPI.as_view("register_confirm")
 )
@@ -406,3 +409,19 @@ def _replace_url_site(url: str, new_site: str) -> str:
     # strip out existing scheme and netloc, so we can replace them with new_site
     url_parsed = urllib.parse.urlunparse(url_parsed._replace(scheme="", netloc=""))
     return urllib.parse.urljoin(new_site, url_parsed)
+
+
+def _send_confirm_registration_email(user: object, access_token: str) -> None:
+    assert isinstance(user, models.User)  # type guard
+    confirm_url = url_for("auth.register_confirm", token=access_token, _external=True)
+    if fe_app_site := current_app.config["FE_APP_SITE"]:
+        confirm_url = _replace_url_site(confirm_url, fe_app_site)
+
+    html = render_template(
+        "emails/user_registration.html", url=confirm_url, name=user.name
+    )
+    if current_app.config["MAIL_SERVER"]:
+        tasks.send_email.apply_async(
+            args=[[user.email], "Confirm your registration", "", html]
+        )
+        current_app.logger.info("registration email sent to %s", user.email)

--- a/colandr/api/v1/routes/auth.py
+++ b/colandr/api/v1/routes/auth.py
@@ -1,29 +1,21 @@
-import functools
-import typing as t
 import urllib.parse
 
 import apiflask as af
-import celery
 import flask_jwt_extended as jwtext
-import redis.client
 import sqlalchemy as sa
 import sqlalchemy.exc
 from flask import current_app, render_template, url_for
 from flask.views import MethodView
 
 from .... import models, tasks
-from ....extensions import db, jwt
-from .. import errors, schemas
+from ....extensions import db
+from .. import authn, errors, schemas
 
 
 bp = af.APIBlueprint("auth", __name__, url_prefix="/auth")
 
 # TODO: can we bolt our system onto apiflask's built-in httptokenauth?
 # auth = af.HTTPTokenAuth(scheme="Bearer")
-
-# TODO: we should use redis for this
-# _JWT_BLOCKLIST = celery.current_app.backend.client  # type: ignore
-_JWT_BLOCKLIST = set()
 
 
 class LoginAPI(MethodView):
@@ -58,7 +50,7 @@ class LoginAPI(MethodView):
         email = json_data["email"]
         password = json_data["password"]
         try:
-            user = authenticate_user(email, password)
+            user = authn.authenticate_user(email, password)
         except ValueError:
             raise errors.NotFoundError(
                 message="no user found matching given email and password"
@@ -91,8 +83,8 @@ class LogoutAPI(MethodView):
         jwt_data = jwtext.get_jwt()
         token = jwt_data["jti"]
         # TODO: we should use redis for this
-        # _JWT_BLOCKLIST.set(token, "", ex=current_app.config["JWT_REFRESH_TOKEN_EXPIRES"])
-        _JWT_BLOCKLIST.add(token)
+        # authn._JWT_BLOCKLIST.set(token, "", ex=current_app.config["JWT_REFRESH_TOKEN_EXPIRES"])
+        authn._JWT_BLOCKLIST.add(token)
         current_app.logger.info("%s logged out", current_user)
         # TODO: do we *need* to return this message, or nah?
         return {"message": f"{current_user} logged out"}
@@ -188,7 +180,7 @@ class ConfirmRegistrationAPI(MethodView):
     )
     def get(self, query_data):
         token: str = query_data["token"]
-        user = get_user_from_token(token)
+        user = authn.get_user_from_token(token)
         if user is None:
             raise errors.NotFoundError(message=f"no user found for token='{token}'")
 
@@ -255,7 +247,7 @@ class ConfirmPasswordResetAPI(MethodView):
     def put(self, query_data, json_data):
         token = query_data["token"]
         password = json_data["password"]
-        user = get_user_from_token(token)
+        user = authn.get_user_from_token(token)
         if user is None:
             raise errors.NotFoundError(message=f"no user found for token='{token}'")
 
@@ -284,124 +276,6 @@ bp.add_url_rule("/reset", view_func=ResetPasswordAPI.as_view("reset"))
 bp.add_url_rule(
     "/reset/confirm", view_func=ConfirmPasswordResetAPI.as_view("reset_confirm")
 )
-
-
-#######################################
-
-
-@jwt.user_identity_loader
-def user_identity_loader(user: models.User | str) -> str:
-    """
-    Callback function that takes the ``User`` passed in as the "identity"
-    when creating JWTs and returns it as a string, either as a stringified ``User.id``
-    or as the email associated with the user.
-    """
-    if isinstance(user, models.User):
-        user_identity = str(user.id)
-    elif isinstance(user, str):
-        user_identity = af.validators.Email()(user)  # validate as email
-    else:
-        raise ValueError(f"user={user} is invalid")
-    return user_identity
-
-
-@jwt.user_lookup_loader
-def user_lookup_callback(_jwt_header, jwt_data: dict) -> t.Optional[models.User]:
-    """
-    Callback function that loads a user from the database by its identity (id)
-    whenever a protected API route is accessed.
-    """
-    user_identity = jwt_data[current_app.config["JWT_IDENTITY_CLAIM"]]
-    if user_identity.isdigit():
-        user = db.session.get(models.User, int(user_identity))
-    elif isinstance(user_identity, str):
-        af.validators.Email()(user_identity)  # validate as email
-        user = db.session.execute(
-            sa.select(models.User).filter_by(email=user_identity)
-        ).scalar_one_or_none()
-    else:
-        raise ValueError(f"user identity={user_identity} is invalid")
-    return user
-
-
-@jwt.additional_claims_loader
-def additional_claims_loader(user: models.User | str) -> dict[str, object]:
-    """Callback function that adds additional claims to the JWT token."""
-    if isinstance(user, models.User):
-        return {"is_admin": user.is_admin}
-    else:
-        return {}
-
-
-@jwt.token_in_blocklist_loader
-def token_in_blocklist_loader(jwt_header, jwt_data: dict) -> bool:
-    """
-    Callback function that checks if a JWT is in the blocklist, i.e. has been revoked.
-    """
-    token = jwt_data["jti"]
-    # TODO: we should use redis for this
-    # token_in_blocklist = _JWT_BLOCKLIST.get(token)
-    token_in_blocklist = token in _JWT_BLOCKLIST
-    return token_in_blocklist
-
-
-def authenticate_user(email: str, password: str) -> models.User:
-    """
-    Verify that password matches the stored password for specified user email;
-    if credentials are valid, the corresponding user instance is returned.
-    """
-    user = db.session.execute(
-        sa.select(models.User).filter_by(email=email)
-    ).scalar_one_or_none()
-    if user is None or user.check_password(password) is False:
-        raise ValueError("invalid user email or password")
-    return user
-
-
-def get_user_from_token(token: str) -> t.Optional[models.User]:
-    """
-    Get a ``User`` from the identity stored in an encoded, unexpired JWT token,
-    if it exists in the database; otherwise, return None.
-    """
-    jwt_data = jwtext.decode_token(token, allow_expired=False)
-    identity = jwt_data[current_app.config["JWT_IDENTITY_CLAIM"]]
-    if identity.isdigit():
-        user = db.session.get(models.User, int(identity))
-    elif isinstance(identity, str):
-        af.validators.Email()(identity)  # validate as email
-        user = db.session.execute(
-            sa.select(models.User).filter_by(email=identity)
-        ).scalar_one_or_none()
-    else:
-        raise TypeError(f"user identity={identity} is invalid")
-    return user
-
-
-def pack_header_for_user(user) -> dict[str, str]:
-    """
-    Create an access token for ``user`` and pack it into a suitable header dict.
-    """
-    token = jwtext.create_access_token(identity=user, fresh=True)
-    header_key = f"{current_app.config['JWT_HEADER_TYPE']} {token}"
-    return {current_app.config["JWT_HEADER_NAME"]: header_key}
-
-
-def jwt_admin_required():
-    def wrapper(fn):
-        @functools.wraps(fn)
-        def decorator(*args, **kwargs):
-            jwtext.verify_jwt_in_request()
-            jwt_data = jwtext.get_jwt()
-            if jwt_data["is_admin"]:
-                return fn(*args, **kwargs)
-            else:
-                raise errors.ForbiddenError(
-                    message="this endpoint is for admin users only"
-                )
-
-        return decorator
-
-    return wrapper
 
 
 def _replace_url_site(url: str, new_site: str) -> str:

--- a/colandr/api/v1/routes/review_teams.py
+++ b/colandr/api/v1/routes/review_teams.py
@@ -10,7 +10,7 @@ from flask.views import MethodView
 
 from .... import models, tasks
 from ....extensions import cache, db
-from .. import authz, errors, schemas
+from .. import authn, authz, errors, schemas
 from . import auth
 
 
@@ -237,7 +237,7 @@ class ReviewTeamConfirmationAPI(MethodView):
     @bp.output(UserSchemaPlusOwner(many=True))
     def get(self, id, query_data):
         token: str = query_data["token"]
-        user = auth.get_user_from_token(token)
+        user = authn.get_user_from_token(token)
         review = db.session.get(models.Review, id)
 
         if not review:

--- a/tests/api/test_admin.py
+++ b/tests/api/test_admin.py
@@ -2,7 +2,7 @@ import flask
 import pytest
 import sqlalchemy as sa
 
-from colandr.api.v1 import auth
+from colandr.api.v1 import authn
 
 from .. import helpers
 
@@ -77,6 +77,6 @@ class TestPostUsersAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.post(
-                    url, data=data, headers=auth.pack_header_for_user(current_user)
+                    url, data=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -4,7 +4,7 @@ import flask_jwt_extended as jwtext
 import pytest
 
 from colandr import models
-from colandr.api.v1 import auth
+from colandr.api.v1 import authn
 
 
 @pytest.mark.parametrize("user_id", [2, 3])
@@ -13,14 +13,14 @@ def test_get_user_from_token(user_id, db_session):
     token = jwtext.create_access_token(
         identity=orig_user, fresh=True, expires_delta=datetime.timedelta(seconds=30)
     )
-    user = auth.get_user_from_token(token)
+    user = authn.get_user_from_token(token)
     assert user is orig_user
 
 
 @pytest.mark.parametrize("user_id", [2, 3])
 def test_pack_header_for_user(user_id, db_session):
     user = db_session.get(models.User, user_id)
-    header = auth.pack_header_for_user(user)
+    header = authn.pack_header_for_user(user)
     assert isinstance(header, dict)
     assert "Authorization" in header
     assert header["Authorization"].startswith("Bearer")

--- a/tests/api/test_citation_screenings.py
+++ b/tests/api/test_citation_screenings.py
@@ -1,7 +1,7 @@
 import flask
 import pytest
 
-from colandr.api.v1 import auth
+from colandr.api.v1 import authn
 
 from .. import helpers
 
@@ -66,7 +66,7 @@ class TestCitationScreeningAPI:
             )
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.get(url, headers=headers)
         assert response.status_code == 200
         data = response.json
@@ -92,7 +92,7 @@ class TestCitationScreeningAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.get(
-                    url, headers=auth.pack_header_for_user(current_user)
+                    url, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code
 
@@ -112,7 +112,7 @@ class TestCitationScreeningAPI:
             url = flask.url_for(CITATION_SCREENING_API_ENDPOINT, id=study_id)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.put(url, json=data, headers=headers)
         assert response.status_code == 200
         obs_data = response.json
@@ -135,7 +135,7 @@ class TestCitationScreeningAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.put(
-                    url, json=data, headers=auth.pack_header_for_user(current_user)
+                    url, json=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code
 
@@ -151,7 +151,7 @@ class TestCitationScreeningAPI:
             url = flask.url_for(CITATION_SCREENING_API_ENDPOINT, id=study_id)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.delete(url, headers=headers)
                 assert response.status_code == 204
                 assert not any(
@@ -173,7 +173,7 @@ class TestCitationScreeningAPI:
             url = flask.url_for(CITATION_SCREENING_API_ENDPOINT, id=study_id)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.delete(url, headers=headers)
                 assert response.status_code == status_code
 

--- a/tests/api/test_reviews.py
+++ b/tests/api/test_reviews.py
@@ -2,7 +2,7 @@ import flask
 import pytest
 import sqlalchemy as sa
 
-from colandr.api.v1 import auth
+from colandr.api.v1 import authn
 
 from .. import helpers
 
@@ -40,7 +40,7 @@ class TestReviewAPI:
             url = flask.url_for(REVIEW_API_ENDPOINT, id=review_id, **(params or {}))
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.get(url, headers=headers)
         assert response.status_code == 200
         data = response.json
@@ -61,7 +61,7 @@ class TestReviewAPI:
             url = flask.url_for(REVIEW_API_ENDPOINT, id=review_id, **(params or {}))
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.get(url, headers=headers)
         assert response.status_code == status_code
 
@@ -81,7 +81,7 @@ class TestReviewAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.put(
-                    url, json=data, headers=auth.pack_header_for_user(current_user)
+                    url, json=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == 200
         obs_data = response.json
@@ -103,7 +103,7 @@ class TestReviewAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.put(
-                    url, json=data, headers=auth.pack_header_for_user(current_user)
+                    url, json=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code
 
@@ -121,7 +121,7 @@ class TestReviewAPI:
             url = flask.url_for(REVIEW_API_ENDPOINT, id=review_id)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.delete(url, headers=headers)
                 assert response.status_code == 204
         assert client.get(url, headers=admin_headers).status_code == 404  # not found!
@@ -140,7 +140,7 @@ class TestReviewAPI:
             url = flask.url_for(REVIEW_API_ENDPOINT, id=review_id)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.delete(url, headers=headers)
                 assert response.status_code == status_code
 
@@ -184,6 +184,6 @@ class TestReviewAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.post(
-                    url, json=data, headers=auth.pack_header_for_user(current_user)
+                    url, json=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code

--- a/tests/api/test_studies.py
+++ b/tests/api/test_studies.py
@@ -1,7 +1,7 @@
 import flask
 import pytest
 
-from colandr.api.v1 import auth
+from colandr.api.v1 import authn
 
 from .. import helpers
 
@@ -48,7 +48,7 @@ class TestStudyAPI:
             url = flask.url_for(STUDY_API_ENDPOINT, id=study_id, **(params or {}))
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.get(url, headers=headers)
         assert response.status_code == 200
         data = response.json
@@ -70,7 +70,7 @@ class TestStudyAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.get(
-                    url, headers=auth.pack_header_for_user(current_user)
+                    url, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code
 
@@ -87,7 +87,7 @@ class TestStudyAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.put(
-                    url, json=data, headers=auth.pack_header_for_user(current_user)
+                    url, json=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == 200
         obs_data = response.json
@@ -111,7 +111,7 @@ class TestStudyAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.put(
-                    url, json=data, headers=auth.pack_header_for_user(current_user)
+                    url, json=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code
 
@@ -127,7 +127,7 @@ class TestStudyAPI:
             url = flask.url_for(STUDY_API_ENDPOINT, id=study_id)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.delete(url, headers=headers)
                 assert response.status_code == 204
                 assert client.get(url, headers=headers).status_code == 404  # not found!
@@ -146,7 +146,7 @@ class TestStudyAPI:
             url = flask.url_for(STUDY_API_ENDPOINT, id=study_id)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.delete(url, headers=headers)
                 assert response.status_code == status_code
 
@@ -184,7 +184,7 @@ class TestStudiesResource:
             url = flask.url_for(STUDIES_API_ENDPOINT, **params)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.get(url, headers=headers)
         assert response.status_code == 200
         obs_data = response.json
@@ -205,6 +205,6 @@ class TestStudiesResource:
             url = flask.url_for(STUDIES_API_ENDPOINT, **params)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.get(url, headers=headers)
         assert response.status_code == status_code

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -1,7 +1,7 @@
 import flask
 import pytest
 
-from colandr.api.v1 import auth
+from colandr.api.v1 import authn
 
 from .. import helpers
 
@@ -76,7 +76,7 @@ class TestUserAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.get(
-                    url, headers=auth.pack_header_for_user(current_user)
+                    url, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == 200
         data = response.json
@@ -99,7 +99,7 @@ class TestUserAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.get(
-                    url, headers=auth.pack_header_for_user(current_user)
+                    url, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code
 
@@ -117,7 +117,7 @@ class TestUserAPI:
             url = flask.url_for(USER_API_ENDPOINT, id=user_id)
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
-                headers = auth.pack_header_for_user(current_user)
+                headers = authn.pack_header_for_user(current_user)
                 response = client.delete(url, headers=headers)
                 assert response.status_code == 204
         assert client.get(url, headers=admin_headers).status_code == 404  # not found!
@@ -137,7 +137,7 @@ class TestUserAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.delete(
-                    url, headers=auth.pack_header_for_user(current_user)
+                    url, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code
 
@@ -156,7 +156,7 @@ class TestUserAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.put(
-                    url, json=data, headers=auth.pack_header_for_user(current_user)
+                    url, json=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == 200
         obs_data = response.json
@@ -183,7 +183,7 @@ class TestUserAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.put(
-                    url, json=data, headers=auth.pack_header_for_user(current_user)
+                    url, json=data, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code
 
@@ -246,6 +246,6 @@ class TestUsersAPI:
         with app.app_context():
             with helpers.set_current_user(current_user_id, db_session) as current_user:
                 response = client.get(
-                    url, headers=auth.pack_header_for_user(current_user)
+                    url, headers=authn.pack_header_for_user(current_user)
                 )
         assert response.status_code == status_code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import sqlalchemy_utils as sa_utils
 from pytest_postgresql import factories as psql_factories
 
 from colandr import cli, extensions, models
-from colandr.api.v1 import auth
+from colandr.api.v1 import authn
 from colandr.app import create_app
 
 
@@ -169,4 +169,4 @@ def admin_user(db: flask_sqlalchemy.SQLAlchemy, app_ctx):
 
 @pytest.fixture(scope="session")
 def admin_headers(admin_user: models.User, app_ctx):
-    return auth.pack_header_for_user(admin_user)
+    return authn.pack_header_for_user(admin_user)


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds `auth/register/resend` api endpoint to re-send a registration confirmation email
- refactors code to share underlying logic with existing `auth/register` endpoint
- refactors authentication ("authn") functions out into their own module, separate from the `auth` endpoints
- allows uncomfirmed users to log in, but limits their authorization to access APIs

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://app.asana.com/0/1206730431337718/1209825705665584/f

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
