### PR TITLE
Improve some nlp utils

### DIFF
--- a/colandr/lib/extractors/locations.py
+++ b/colandr/lib/extractors/locations.py
@@ -6,7 +6,7 @@ import typing as t
 
 from spacy.tokens import Span
 
-from ..nlp.utils import process_texts_into_docs
+from ..nlp.utils import process_text_into_doc
 from .metadata import Metadata
 
 
@@ -50,8 +50,7 @@ class LocationExtractor:
         if not text or not text.strip():
             return []
 
-        processed_docs_iter = process_texts_into_docs([text], max_len=None)
-        doc = next(iter(processed_docs_iter), None)
+        doc = process_text_into_doc(text, max_len=None)
         if doc is None:
             return []
 

--- a/colandr/lib/extractors/review_model.py
+++ b/colandr/lib/extractors/review_model.py
@@ -17,7 +17,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import MultiLabelBinarizer, StandardScaler
 from spacy.tokens import Doc, Span
 
-from ..nlp.utils import process_texts_into_docs
+from ..nlp.utils import process_text_into_doc, process_texts_into_docs
 from .metadata import Metadata
 
 
@@ -444,10 +444,7 @@ class ReviewModel:
             Tuple containing the feature DataFrame and original sentences list.
         """
         main_content, _ = self._split_references(text_content)
-        processed_docs_iter = process_texts_into_docs(
-            [main_content], max_len=None, exclude=("ner",)
-        )
-        doc = next(iter(processed_docs_iter), None)
+        doc = process_text_into_doc(main_content, max_len=None, exclude=("ner",))
         return self._extract_features_from_doc(doc)
 
     def _is_valid_sentence(self, sent: Optional[Span]) -> bool:

--- a/colandr/lib/nlp/utils.py
+++ b/colandr/lib/nlp/utils.py
@@ -45,6 +45,7 @@ def detect_languages(texts: Iterable[str]) -> list[t.Optional[str]]:
     ]
 
 
+@functools.cache
 def get_lang_to_models() -> dict[str, str]:
     """Get a mapping of ISO language code to installed spacy language models."""
     lang_to_models = {}

--- a/colandr/lib/nlp/utils.py
+++ b/colandr/lib/nlp/utils.py
@@ -90,6 +90,41 @@ def load_spacy_lang(name: str, **kwargs) -> SpacyLang:
     return spacy_lang
 
 
+def process_text_into_doc(
+    text: str,
+    *,
+    max_len: t.Optional[int] = 1000,
+    fallback_lang: t.Optional[str] = "en",
+    **kwargs,
+) -> t.Optional[SpacyDoc]:
+    """
+    Args:
+        text
+        max_len: Maximum number of chars (code points) in text to include
+            when identifying its language and processing into a spacy document.
+        fallback_lang: Fallback language used in place of low-confidence predictions.
+        **kwargs: Passed as-is into :func:`load_spacy_lang()` .
+    """
+    # clean up whitespace, to make it easier on lang detector
+    text = text.strip().replace("\n", " ")
+    # truncate texts, optionally
+    if max_len is not None:
+        text = text[:max_len]
+    # identify most probable language (w/ optional fallback) for text
+    lang = detect_language(text) or fallback_lang
+    lang_models = get_lang_to_models()
+    if lang in lang_models:
+        spacy_lang: SpacyLang = load_spacy_lang(lang_models[lang], **kwargs)
+        spacy_doc = spacy_lang(text)
+        return spacy_doc
+    else:
+        LOGGER.info(
+            "unable to load spacy model for text with lang='%s'; doc set to null ...",
+            lang,
+        )
+        return None
+
+
 def process_texts_into_docs(
     texts: Iterable[str],
     *,

--- a/colandr/lib/nlp/utils.py
+++ b/colandr/lib/nlp/utils.py
@@ -45,18 +45,18 @@ def detect_languages(texts: Iterable[str]) -> list[t.Optional[str]]:
     ]
 
 
-def get_lang_to_models() -> dict[str, list[str]]:
+def get_lang_to_models() -> dict[str, str]:
     """Get a mapping of ISO language code to installed spacy language models."""
-    lang_to_models = collections.defaultdict(list)
+    lang_to_models = {}
     models = spacy.util.get_installed_models()
     for model in models:
         if "_" in model:
             lang, _ = model.split("_", 1)
-            lang_to_models[lang].append(model)
+            lang_to_models[lang] = model
         else:
             LOGGER.warning("found unexpected spacy model name: %s", model)
 
-    return dict(lang_to_models)
+    return lang_to_models
 
 
 @functools.lru_cache(maxsize=10)
@@ -120,7 +120,7 @@ def process_texts_into_docs(
     lang_models = get_lang_to_models()
     for lang, tl_grp in itertools.groupby(text_langs, key=itemgetter(1)):
         if lang in lang_models:
-            spacy_lang = load_spacy_lang(lang_models[lang][0], **kwargs)
+            spacy_lang = load_spacy_lang(lang_models[lang], **kwargs)
             spacy_docs = spacy_lang.pipe((text for text, _ in tl_grp), n_process=1)
             for spacy_doc in spacy_docs:
                 yield spacy_doc

--- a/colandr/tasks.py
+++ b/colandr/tasks.py
@@ -295,13 +295,12 @@ def get_fulltext_text_content_vector(fulltext_id: int):
         )
         return
 
-    docs = nlp_utils.process_texts_into_docs(
-        [fulltext["text_content"]],
+    doc = nlp_utils.process_text_into_doc(
+        fulltext["text_content"],
         max_len=3000,
         fallback_lang=None,
         exclude=("parser", "ner"),
     )
-    doc = next(iter(docs))
     text_content_vector_rep = doc.vector.tolist() if doc is not None else None
     if text_content_vector_rep is None:
         LOGGER.warning(
@@ -310,12 +309,12 @@ def get_fulltext_text_content_vector(fulltext_id: int):
         return
 
     fulltext["text_content_vector_rep"] = text_content_vector_rep
-    stmt = (
+    update_stmt = (
         sa.update(models.Study)
         .where(models.Study.id == fulltext_id)
         .values(fulltext=fulltext)
     )
-    db.session.execute(stmt)
+    db.session.execute(update_stmt)
     db.session.commit()
 
 

--- a/tests/lib/extractors/test_locations.py
+++ b/tests/lib/extractors/test_locations.py
@@ -48,8 +48,8 @@ class TestLocationExtractor:
 
             assert extractor.is_in_reference(mock_ent) is False
 
-    @patch("colandr.lib.extractors.locations.process_texts_into_docs")
-    def test_extract_locations(self, mock_process_texts):
+    @patch("colandr.lib.extractors.locations.process_text_into_doc")
+    def test_extract_locations(self, mock_process_text):
         """Test extract_locations function."""
         extractor = LocationExtractor()
 
@@ -80,7 +80,7 @@ class TestLocationExtractor:
 
         mock_doc.ents = [mock_ent1, mock_ent2]
 
-        mock_process_texts.return_value = iter([mock_doc])
+        mock_process_text.return_value = mock_doc
 
         extractor.is_in_reference = MagicMock(return_value=False)
 

--- a/tests/lib/extractors/test_review_model.py
+++ b/tests/lib/extractors/test_review_model.py
@@ -120,8 +120,8 @@ class TestReviewModel:
             assert retrained is False
             mock_train.assert_not_called()
 
-    @patch("colandr.lib.extractors.review_model.process_texts_into_docs")
-    def test_extract_metadata(self, mock_process_texts):
+    @patch("colandr.lib.extractors.review_model.process_text_into_doc")
+    def test_extract_metadata(self, mock_process_text):
         """Test the full metadata extraction integration."""
         model = ReviewModel()
 
@@ -141,11 +141,11 @@ class TestReviewModel:
         mock_sent = self._create_mock_sentence(sent_text, has_verb=True)
         mock_doc = MagicMock()
         mock_doc.sents = [mock_sent]
-        mock_process_texts.return_value = iter([mock_doc])
+        mock_process_text.return_value = mock_doc
 
         results = model.extract_metadata(123, "some input text", threshold=0.5)
 
-        mock_process_texts.assert_called_once()
+        mock_process_text.assert_called_once()
         assert len(results) == 1
         result = results[0]
         assert result.record == 123

--- a/tests/lib/nlp/test_utils.py
+++ b/tests/lib/nlp/test_utils.py
@@ -79,6 +79,34 @@ def test_detect_languages(texts, exp_langs):
 
 
 @pytest.mark.parametrize(
+    ["text", "max_len", "fallback_lang"],
+    [
+        (
+            "This is a short -- but not too short -- example English sentence.",
+            1000,
+            None,
+        ),
+        ("And this is another short example English sentence.", 100, "en"),
+        ("Esta es una frase corta de ejemplo en español.", None, None),
+    ],
+)
+def test_process_text_into_doc(text, max_len, fallback_lang, app):
+    doc = utils.process_text_into_doc(
+        text,
+        max_len=max_len,
+        fallback_lang=fallback_lang,
+        exclude=("parser", "ner"),
+    )
+    assert isinstance(doc, Doc) or doc is None
+    if doc.lang_ == "en":
+        spacy_lang = utils.load_spacy_lang(
+            utils.get_lang_to_models()["en"], exclude=("parser", "ner")
+        )
+        assert isinstance(spacy_lang, Language) and isinstance(doc, Doc)  # type guards
+        assert spacy_lang(text).to_bytes() == doc.to_bytes()
+
+
+@pytest.mark.parametrize(
     ["texts", "max_len", "fallback_lang"],
     [
         (

--- a/tests/lib/nlp/test_utils.py
+++ b/tests/lib/nlp/test_utils.py
@@ -124,7 +124,7 @@ def test_process_texts_into_docs(texts, max_len, fallback_lang, app):
     assert any(isinstance(doc, Doc) for doc in docs)
     # sanity-check vector value for first text only
     spacy_lang = utils.load_spacy_lang(
-        utils.get_lang_to_models()["en"][0], exclude=("parser", "ner")
+        utils.get_lang_to_models()["en"], exclude=("parser", "ner")
     )
     doc = docs[0]
     assert isinstance(spacy_lang, Language) and isinstance(doc, Doc)  # type guards


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- add `process_text_into_doc()` func as the single-input equivalent to existing `process_texts_into_docs()`, and swap it in places where only a single text was used as input
- simplifies mapping of language code to spacy model, since only one is ever needed or installed

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

cleaning up a rough edge, for performance and simplicity

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
