### PR TITLE
improve password reset email

### DIFF
--- a/colandr/api/v1/routes/auth.py
+++ b/colandr/api/v1/routes/auth.py
@@ -1,3 +1,4 @@
+import datetime
 import urllib.parse
 
 import apiflask as af
@@ -215,13 +216,21 @@ class ResetPasswordAPI(MethodView):
             )
             return
 
-        access_token = jwtext.create_access_token(identity=user, fresh=False)
+        token_expiration_minutes = 15
+        access_token = jwtext.create_access_token(
+            identity=user,
+            fresh=False,
+            expires_delta=datetime.timedelta(minutes=token_expiration_minutes),
+        )
         confirm_url = url_for("auth.reset_confirm", token=access_token, _external=True)
         if fe_app_site := current_app.config["FE_APP_SITE"]:
             confirm_url = _replace_url_site(confirm_url, fe_app_site)
 
         html = render_template(
-            "emails/password_reset.html", url=confirm_url, name=user.name
+            "emails/password_reset_v2.html",
+            url=confirm_url,
+            name=user.name,
+            expiration_minutes=token_expiration_minutes,
         )
         if current_app.config["MAIL_SERVER"]:
             tasks.send_email.apply_async(

--- a/colandr/templates/emails/password_reset_v2.html
+++ b/colandr/templates/emails/password_reset_v2.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Colandr - reset your password</title>
+    </head>
+    <div
+        style="margin: 0; padding: 0; background-color: #f5f7fa; font-family: Arial, Helvetica, sans-serif; line-height: 1.6;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+            style="border-collapse: collapse;">
+            <tr>
+                <td align="center" style="padding: 40px 0;">
+                    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0"
+                        style="max-width: 600px; background-color: #ffffff; border: 1px solid #e5e7eb; border-collapse: collapse;">
+                        <!-- Header -->
+                        <tr>
+                            <td style="background-color: #4353b3; padding: 32px 40px; text-align: center;">
+                                <h1 style="font-size: 24px; font-weight: 700; color: #ffffff; margin: 0;">colandr</h1>
+                            </td>
+                        </tr>
+
+                        <!-- Content -->
+                        <tr>
+                            <td style="padding: 40px 40px 32px;">
+                                <h3 style="font-size: 18px; font-weight: 600; color: #1f2937; margin: 0 0 24px 0;">Hi,
+                                    {{ name }}!</h3>
+                                <p style="font-size: 15px; color: #4b5563; margin: 0 0 0px 0; line-height: 1.7;">
+                                    A password reset request has recently been made for this email address. Please click
+                                    the link below to reset it. This link will expire in {{ expiration_minutes }}
+                                    minutes.
+                                </p>
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                                    style="border-collapse: collapse;">
+                                    <tr>
+                                        <td align="center" style="padding: 24px 0;">
+                                            <a href="{{ url }}" target="_blank"
+                                                style="display: inline-block; padding: 14px 36px; background-color: #4353b3; color: #ffffff; text-decoration: none; font-weight: 600; font-size: 15px;">reset
+                                                my password</a>
+                                        </td>
+                                    </tr>
+                                </table>
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                                    style="border-collapse: collapse;">
+                                    <tr>
+                                        <td
+                                            style="padding: 14px 16px; background-color: #fef3c7; border-left: 3px solid #f59e0b; font-size: 13px; color: #92400e;">
+                                            <strong>Note:</strong> If you didn't request this password reset, you can
+                                            safely ignore this email.
+                                        </td>
+                                    </tr>
+                                </table>
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                                    style="border-collapse: collapse;">
+                                    <tr>
+                                        <td
+                                            style="padding-top: 32px; border-top: 1px solid #e5e7eb; font-size: 15px; color: #1f2937;">
+                                            <p style="font-weight: 600; margin: 0;">Cheers,</p>
+                                            <p style="margin: 4px 0 0 0; color: #6b7280;">The Colandr Team</p>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <!-- Footer -->
+                        <tr>
+                            <td
+                                style="padding: 24px 40px; text-align: center; font-size: 12px; color: #9ca3af; background-color: #f9fafb; border-top: 1px solid #e5e7eb;">
+                                <p style="margin: 4px 0;">This is an automated message. Please do not reply to this
+                                    email.</p>
+                                <p style="margin: 4px 0;">&copy; 2026 colandr. All rights reserved.</p>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+</html>

--- a/colandr/templates/emails/password_reset_v2.html
+++ b/colandr/templates/emails/password_reset_v2.html
@@ -6,7 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Colandr - reset your password</title>
     </head>
-    <div
+
+    <body
         style="margin: 0; padding: 0; background-color: #f5f7fa; font-family: Arial, Helvetica, sans-serif; line-height: 1.6;">
         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
             style="border-collapse: collapse;">
@@ -26,7 +27,7 @@
                             <td style="padding: 40px 40px 32px;">
                                 <h3 style="font-size: 18px; font-weight: 600; color: #1f2937; margin: 0 0 24px 0;">Hi,
                                     {{ name }}!</h3>
-                                <p style="font-size: 15px; color: #4b5563; margin: 0 0 0px 0; line-height: 1.7;">
+                                <p style="font-size: 15px; color: #4b5563; margin: 0 0 0 0; line-height: 1.7;">
                                     A password reset request has recently been made for this email address. Please click
                                     the link below to reset it. This link will expire in {{ expiration_minutes }}
                                     minutes.
@@ -77,6 +78,6 @@
                 </td>
             </tr>
         </table>
-    </div>
+    </body>
 
 </html>


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

old password reset email:

<img width="930" height="297" alt="image" src="https://github.com/user-attachments/assets/f9f139a6-ad11-41b0-894d-cd2eeff08804" />

new password reset email:

<img width="930" height="702" alt="image" src="https://github.com/user-attachments/assets/ddfc7268-2ba7-4700-819c-48cb1b93104b" />

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

since everyone will have to reset their emails post-migration... we should put on a nice face for it

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- any concerns about the expiring token? (that's standard, right??)
- any concerns about the in-line css styling? based on my checks, this email's compatibility with clients is at 90% fully and 8% partially supported; i'm willing to chance the tiny slice of unsupported features/clients if you are!
- shall i try to update the other email templates similarly?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a time-limited reset flow and a redesigned email.
> 
> - In `ResetPasswordAPI`, create reset JWTs with `expires_delta` of 15 minutes and pass `expiration_minutes` to the template
> - Replace email template from `emails/password_reset.html` to new styled `emails/password_reset_v2.html` including CTA and expiry notice
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aad0f395c041e0113d70c6b6c6519672d1b68f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->