### PR TITLE
improve+ORMify review progress queries

### DIFF
--- a/colandr/api/v1/routes/review_progress.py
+++ b/colandr/api/v1/routes/review_progress.py
@@ -208,7 +208,7 @@ class ReviewProgressAPI(MethodView):
             elif step == "citation_screening":
                 stmt = (
                     sa.select(models.Study.citation_status, sa.func.count())
-                    .filter_by(review_id=id)
+                    .filter_by(review_id=id, dedupe_status="not_duplicate")
                     .group_by(models.Study.citation_status)
                 )
                 progress = (

--- a/colandr/api/v1/routes/review_progress.py
+++ b/colandr/api/v1/routes/review_progress.py
@@ -104,7 +104,12 @@ class ReviewProgressAPI(MethodView):
                 "data_extraction_form": bool(review_plan.data_extraction_form),
             }
             response["planning"] = progress
-        if step in ("data_extraction", "all"):
+        if (
+            # there's a fast-track path for user_view=False and step == "all"
+            (step == "data_extraction" and user_view is False)
+            # but no such path for user_view=True
+            or (step in ("data_extraction", "all") and user_view is True)
+        ):
             stmt = (
                 sa.select(models.Study.data_extraction_status, sa.func.count())
                 .filter_by(review_id=id, fulltext_status="included")
@@ -123,33 +128,84 @@ class ReviewProgressAPI(MethodView):
         if user_view is False:
             # compute all screening status counts using a single query, for perf reasons
             if step == "all":
-                # get all screening steps' statuses for review studies
-                stmt = sa.select(
-                    models.Study.citation_status,
-                    models.Study.fulltext_status,
-                ).filter_by(review_id=id)
-                rows = db.session.execute(stmt).mappings().all()
-                # ensure every status is included, i.e. 0 count instead of null/missing
-                progress = {
-                    "citation_screening": {
-                        ss: 0 for ss in constants.SCREENING_STATUSES
-                    },
-                    "fulltext_screening": {
-                        ss: 0 for ss in constants.SCREENING_STATUSES
-                    },
-                }
-                # compute the counts in python rather than sql, for convenience
-                progress["citation_screening"] |= dict(
-                    collections.Counter(row["citation_status"] for row in rows)
-                    # TODO: do we want to filter to dedupe_status == "not_duplicate" ?
-                )
-                progress["fulltext_screening"] |= dict(
-                    collections.Counter(
-                        row["fulltext_status"]
-                        for row in rows
-                        if row["citation_status"] == "included"
+                # get all steps' statuses for review studies
+                statuses_cte = (
+                    sa.select(
+                        models.Study.dedupe_status,
+                        models.Study.citation_status,
+                        models.Study.fulltext_status,
+                        models.Study.data_extraction_status,
                     )
+                    .filter_by(review_id=id)
+                    .cte("statuses")
                 )
+                # aggregate counts of each step's statuses
+                cs_counts_cte = (
+                    sa.select(
+                        statuses_cte.c.citation_status.label("status"),
+                        sa.func.count().label("cnt"),
+                    )
+                    .where(statuses_cte.c.dedupe_status == "not_duplicate")
+                    .group_by(statuses_cte.c.citation_status)
+                    .cte("cs_counts")
+                )
+                fs_counts_cte = (
+                    sa.select(
+                        statuses_cte.c.fulltext_status.label("status"),
+                        sa.func.count().label("cnt"),
+                    )
+                    .where(statuses_cte.c.citation_status == "included")
+                    .group_by(statuses_cte.c.fulltext_status)
+                    .cte("fs_counts")
+                )
+                des_counts_cte = (
+                    sa.select(
+                        statuses_cte.c.data_extraction_status.label("status"),
+                        sa.func.count().label("cnt"),
+                    )
+                    .where(statuses_cte.c.fulltext_status == "included")
+                    .group_by(statuses_cte.c.data_extraction_status)
+                    .cte("des_counts")
+                )
+                # aggregate each step's status counts into a json blob, taking care
+                # to fall back to an empty json blob in case step is missing data
+                cs_json_cte = sa.select(
+                    sa.func.coalesce(
+                        sa.func.json_object_agg(
+                            cs_counts_cte.c.status, cs_counts_cte.c.cnt
+                        ),
+                        sa.text("'{}'::json"),
+                    ).label("citation_screening"),
+                ).cte("cs_json")
+                fs_json_cte = sa.select(
+                    sa.func.coalesce(
+                        sa.func.json_object_agg(
+                            fs_counts_cte.c.status, fs_counts_cte.c.cnt
+                        ),
+                        sa.text("'{}'::json"),
+                    ).label("fulltext_screening"),
+                ).cte("fs_json")
+                des_json_cte = sa.select(
+                    sa.func.coalesce(
+                        sa.func.json_object_agg(
+                            des_counts_cte.c.status, des_counts_cte.c.cnt
+                        ),
+                        sa.text("'{}'::json"),
+                    ).label("data_extraction"),
+                ).cte("des_json")
+                # cross join all together into a single row
+                stmt = sa.select(cs_json_cte, fs_json_cte, des_json_cte)
+                row = db.session.execute(stmt).mappings().one()
+                # set default values for all statuses
+                # then override actual values for occurring statuses
+                progress = {
+                    "citation_screening": {ss: 0 for ss in constants.SCREENING_STATUSES}
+                    | row["citation_screening"],
+                    "fulltext_screening": {ss: 0 for ss in constants.SCREENING_STATUSES}
+                    | row["fulltext_screening"],
+                    "data_extraction": {es: 0 for es in constants.EXTRACTION_STATUSES}
+                    | row["data_extraction"],
+                }
                 response |= progress
             elif step == "citation_screening":
                 stmt = (

--- a/colandr/api/v1/routes/review_progress.py
+++ b/colandr/api/v1/routes/review_progress.py
@@ -1,3 +1,5 @@
+import collections
+
 import apiflask as af
 import flask_jwt_extended as jwtext
 import sqlalchemy as sa
@@ -90,6 +92,7 @@ class ReviewProgressAPI(MethodView):
             )
 
         response = {}
+        # these first two steps are the same, regardless of user_view
         if step in ("planning", "all"):
             review_plan = review.review_plan
             progress = {
@@ -101,120 +104,206 @@ class ReviewProgressAPI(MethodView):
                 "data_extraction_form": bool(review_plan.data_extraction_form),
             }
             response["planning"] = progress
-        if step in ("citation_screening", "all"):
-            if user_view is False:
-                progress = {status: 0 for status in constants.SCREENING_STATUSES}
-                progress_stmt = (
-                    sa.select(models.Study.citation_status, sa.func.count())
-                    .filter_by(review_id=id)
-                    .group_by(models.Study.citation_status)
-                )
-                progress |= {
-                    row.citation_status: row.count
-                    for row in db.session.execute(progress_stmt)
-                }
-            else:
-                # TODO: figure out how to ORM-ify this
-                query = """
-                    SELECT
-                        (CASE
-                             WHEN citation_status IN ('included', 'excluded', 'conflict') THEN citation_status
-                             WHEN citation_status = 'screened_once' AND {user_id} = ANY(user_ids) THEN 'awaiting_coscreener'
-                             WHEN citation_status = 'not_screened' OR NOT {user_id} = ANY(user_ids) THEN 'pending'
-                         END) AS user_status,
-                         COUNT(*)
-                    FROM (
-                        SELECT
-                            studies.id,
-                            studies.dedupe_status,
-                            studies.citation_status,
-                            screenings_.user_ids
-                        FROM studies
-                        LEFT JOIN (
-                            SELECT
-                                study_id,
-                                ARRAY_AGG(user_id) AS user_ids
-                            FROM screenings
-                            WHERE stage = 'citation'
-                            GROUP BY study_id
-                        ) AS screenings_ ON studies.id = screenings_.study_id
-                        WHERE review_id = {review_id}
-                    ) AS t
-                    WHERE dedupe_status = 'not_duplicate'  -- this is necessary!
-                    GROUP BY user_status;
-                    """.format(user_id=current_user.id, review_id=id)
-                progress = {
-                    row.user_status: row.count
-                    for row in db.session.execute(sa.text(query))
-                }
-                progress = {
-                    status: progress.get(status, 0)
-                    for status in constants.USER_SCREENING_STATUSES
-                }
-            response["citation_screening"] = progress
-        if step in ("fulltext_screening", "all"):
-            if user_view is False:
-                progress = {status: 0 for status in constants.SCREENING_STATUSES}
-                progress_stmt = (
-                    sa.select(models.Study.fulltext_status, sa.func.count())
-                    .filter_by(review_id=id, citation_status="included")
-                    .group_by(models.Study.fulltext_status)
-                )
-                progress |= {
-                    row.fulltext_status: row.count
-                    for row in db.session.execute(progress_stmt)
-                }
-            else:
-                # TODO: figure out how to ORM-ify this
-                query = """
-                    SELECT
-                        (CASE
-                             WHEN fulltext_status IN ('included', 'excluded', 'conflict') THEN fulltext_status
-                             WHEN fulltext_status = 'not_screened' OR NOT {user_id} = ANY(user_ids) THEN 'pending'
-                             WHEN fulltext_status = 'screened_once' AND {user_id} = ANY(user_ids) THEN 'awaiting_coscreener'
-                         END) AS user_status,
-                         COUNT(*)
-                    FROM (
-                        SELECT
-                            studies.id,
-                            studies.citation_status,
-                            studies.fulltext_status,
-                            screenings_.user_ids
-                        FROM studies
-                        LEFT JOIN (
-                            SELECT
-                                study_id,
-                                ARRAY_AGG(user_id) AS user_ids
-                            FROM screenings
-                            WHERE stage = 'fulltext'
-                            GROUP BY study_id
-                        ) AS screenings_ ON studies.id = screenings_.study_id
-                        WHERE review_id = {review_id}
-                    ) AS t
-                    WHERE citation_status = 'included'  -- this is necessary!
-                    GROUP BY user_status;
-                    """.format(user_id=current_user.id, review_id=id)
-                progress = {
-                    row.user_status: row.count
-                    for row in db.session.execute(sa.text(query))
-                }
-                progress = {
-                    status: progress.get(status, 0)
-                    for status in constants.USER_SCREENING_STATUSES
-                }
-            response["fulltext_screening"] = progress
         if step in ("data_extraction", "all"):
-            progress = {status: 0 for status in constants.EXTRACTION_STATUSES}
-            progress_stmt = (
+            stmt = (
                 sa.select(models.Study.data_extraction_status, sa.func.count())
                 .filter_by(review_id=id, fulltext_status="included")
                 .group_by(models.Study.data_extraction_status)
             )
-            progress |= {
-                row.data_extraction_status: row.count
-                for row in db.session.execute(progress_stmt)
-            }
+            progress = (
+                # set default values for all statuses
+                {status: 0 for status in constants.EXTRACTION_STATUSES}
+                # override actual values for occurring statuses
+                | {
+                    row.data_extraction_status: row.count
+                    for row in db.session.execute(stmt)
+                }
+            )
             response["data_extraction"] = progress
+        if user_view is False:
+            # compute all screening status counts using a single query, for perf reasons
+            if step == "all":
+                # get all screening steps' statuses for review studies
+                stmt = sa.select(
+                    models.Study.citation_status,
+                    models.Study.fulltext_status,
+                ).filter_by(review_id=id)
+                rows = db.session.execute(stmt).mappings().all()
+                # ensure every status is included, i.e. 0 count instead of null/missing
+                progress = {
+                    "citation_screening": {
+                        ss: 0 for ss in constants.SCREENING_STATUSES
+                    },
+                    "fulltext_screening": {
+                        ss: 0 for ss in constants.SCREENING_STATUSES
+                    },
+                }
+                # compute the counts in python rather than sql, for convenience
+                progress["citation_screening"] |= dict(
+                    collections.Counter(row["citation_status"] for row in rows)
+                    # TODO: do we want to filter to dedupe_status == "not_duplicate" ?
+                )
+                progress["fulltext_screening"] |= dict(
+                    collections.Counter(
+                        row["fulltext_status"]
+                        for row in rows
+                        if row["citation_status"] == "included"
+                    )
+                )
+                response |= progress
+            elif step == "citation_screening":
+                stmt = (
+                    sa.select(models.Study.citation_status, sa.func.count())
+                    .filter_by(review_id=id)
+                    .group_by(models.Study.citation_status)
+                )
+                progress = (
+                    # set default values for all statuses
+                    {status: 0 for status in constants.SCREENING_STATUSES}
+                    # override actual values for occurring statuses
+                    | {
+                        row.citation_status: row.count
+                        for row in db.session.execute(stmt)
+                    }
+                )
+                response["citation_screening"] = progress
+            elif step == "fulltext_screening":
+                stmt = (
+                    sa.select(models.Study.fulltext_status, sa.func.count())
+                    .filter_by(review_id=id, citation_status="included")
+                    .group_by(models.Study.fulltext_status)
+                )
+                progress = (
+                    # set default values for all statuses
+                    {status: 0 for status in constants.SCREENING_STATUSES}
+                    # override actual values for occurring statuses
+                    | {
+                        row.fulltext_status: row.count
+                        for row in db.session.execute(stmt)
+                    }
+                )
+                response["fulltext_screening"] = progress
+        else:
+            if step in ("citation_screening", "all"):
+                user_id = current_user.id
+                screenings_cte = (
+                    sa.select(
+                        models.Screening.study_id,
+                        sa.func.array_agg(models.Screening.user_id).label("user_ids"),
+                    )
+                    .filter_by(review_id=id, stage="citation")
+                    .group_by(models.Screening.study_id)
+                    .cte("screenings_")
+                )
+                studies_cte = (
+                    sa.select(
+                        models.Study.id,
+                        models.Study.citation_status,
+                        screenings_cte.c.user_ids,
+                    )
+                    .outerjoin(
+                        screenings_cte, models.Study.id == screenings_cte.c.study_id
+                    )
+                    .where(
+                        models.Study.review_id == id,
+                        models.Study.dedupe_status == "not_duplicate",
+                    )
+                    .cte("studies_")
+                )
+                user_status = sa.case(
+                    (
+                        studies_cte.c.citation_status.in_(
+                            ["included", "excluded", "conflict"]
+                        ),
+                        studies_cte.c.citation_status,
+                    ),
+                    (
+                        sa.and_(
+                            studies_cte.c.citation_status == "screened_once",
+                            user_id == sa.any_(studies_cte.c.user_ids),
+                        ),
+                        "awaiting_coscreener",
+                    ),
+                    (
+                        sa.or_(
+                            studies_cte.c.citation_status == "not_screened",
+                            user_id != sa.any_(studies_cte.c.user_ids),
+                        ),
+                        "pending",
+                    ),
+                ).label("user_status")
+                stmt = (
+                    sa.select(user_status, sa.func.count().label("count"))
+                    .select_from(studies_cte)
+                    .group_by(user_status)
+                )
+                progress = (
+                    # set default values for all statuses
+                    {status: 0 for status in constants.SCREENING_STATUSES}
+                    # override actual values for occurring statuses
+                    | {row.user_status: row.count for row in db.session.execute(stmt)}
+                )
+                response["citation_screening"] = progress
+            if step in ("fulltext_screening", "all"):
+                user_id = current_user.id
+                screenings_cte = (
+                    sa.select(
+                        models.Screening.study_id,
+                        sa.func.array_agg(models.Screening.user_id).label("user_ids"),
+                    )
+                    .filter_by(review_id=id, stage="fulltext")
+                    .group_by(models.Screening.study_id)
+                    .cte("screenings_")
+                )
+                studies_cte = (
+                    sa.select(
+                        models.Study.id,
+                        models.Study.fulltext_status,
+                        screenings_cte.c.user_ids,
+                    )
+                    .outerjoin(
+                        screenings_cte, models.Study.id == screenings_cte.c.study_id
+                    )
+                    .where(
+                        models.Study.review_id == id,
+                        models.Study.citation_status == "included",
+                    )
+                    .cte("studies_")
+                )
+                user_status = sa.case(
+                    (
+                        studies_cte.c.fulltext_status.in_(
+                            ["included", "excluded", "conflict"]
+                        ),
+                        studies_cte.c.fulltext_status,
+                    ),
+                    (
+                        sa.and_(
+                            studies_cte.c.fulltext_status == "screened_once",
+                            user_id == sa.any_(studies_cte.c.user_ids),
+                        ),
+                        "awaiting_coscreener",
+                    ),
+                    (
+                        sa.or_(
+                            studies_cte.c.fulltext_status == "not_screened",
+                            user_id != sa.any_(studies_cte.c.user_ids),
+                        ),
+                        "pending",
+                    ),
+                ).label("user_status")
+                stmt = (
+                    sa.select(user_status, sa.func.count().label("count"))
+                    .select_from(studies_cte)
+                    .group_by(user_status)
+                )
+                progress = (
+                    # set default values for all statuses
+                    {status: 0 for status in constants.SCREENING_STATUSES}
+                    # override actual values for occurring statuses
+                    | {row.user_status: row.count for row in db.session.execute(stmt)}
+                )
+                response["fulltext_screening"] = progress
 
         current_app.logger.debug("%s got progress for %s", current_user, review)
         return response

--- a/colandr/api/v1/routes/review_progress.py
+++ b/colandr/api/v1/routes/review_progress.py
@@ -281,7 +281,7 @@ class ReviewProgressAPI(MethodView):
                     (
                         sa.or_(
                             studies_cte.c.citation_status == "not_screened",
-                            user_id != sa.any_(studies_cte.c.user_ids),
+                            ~(user_id == sa.any_(studies_cte.c.user_ids)),
                         ),
                         "pending",
                     ),
@@ -341,7 +341,7 @@ class ReviewProgressAPI(MethodView):
                     (
                         sa.or_(
                             studies_cte.c.fulltext_status == "not_screened",
-                            user_id != sa.any_(studies_cte.c.user_ids),
+                            ~(user_id == sa.any_(studies_cte.c.user_ids)),
                         ),
                         "pending",
                     ),

--- a/colandr/api/v1/routes/review_progress.py
+++ b/colandr/api/v1/routes/review_progress.py
@@ -293,7 +293,7 @@ class ReviewProgressAPI(MethodView):
                 )
                 progress = (
                     # set default values for all statuses
-                    {status: 0 for status in constants.SCREENING_STATUSES}
+                    {status: 0 for status in constants.USER_SCREENING_STATUSES}
                     # override actual values for occurring statuses
                     | {row.user_status: row.count for row in db.session.execute(stmt)}
                 )
@@ -353,7 +353,7 @@ class ReviewProgressAPI(MethodView):
                 )
                 progress = (
                     # set default values for all statuses
-                    {status: 0 for status in constants.SCREENING_STATUSES}
+                    {status: 0 for status in constants.USER_SCREENING_STATUSES}
                     # override actual values for occurring statuses
                     | {row.user_status: row.count for row in db.session.execute(stmt)}
                 )

--- a/colandr/api/v1/routes/review_progress.py
+++ b/colandr/api/v1/routes/review_progress.py
@@ -1,5 +1,3 @@
-import collections
-
 import apiflask as af
 import flask_jwt_extended as jwtext
 import sqlalchemy as sa


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- ORM-ifies all queries in the GET review_progress endpoint, for consistency and protection against data model changes not being reflected in SQL statements
- adds fast-track path for default case of `user_view=False` and `step="all"` using a single query to compute all status counts

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://app.asana.com/1/6325821815997/project/1206730431337718/task/1212815941831470?focus=true

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes `GET /reviews/<id>/progress` by replacing raw SQL with SQLAlchemy queries and adding an optimized aggregation path.
> 
> - Replaces raw SQL with ORM/CTE-based queries for `citation_screening`, `fulltext_screening`, and `data_extraction`, including user-view computations via `Screening` joins and `CASE` logic
> - Adds fast-track path for `user_view=False` and `step="all"` to compute all step status counts in a single query (using CTEs and `json_object_agg`), improving performance
> - Ensures default status keys are always present by pre-seeding counts and overlaying query results; maintains filtering constraints (`dedupe_status='not_duplicate'`, `citation_status='included'`, `fulltext_status='included'`)
> - Minor restructure: early handling of `data_extraction` and consolidated response construction
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f43a35ad16832efedeca67e92d02173eff2b7ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->