### PR TITLE
fix: auth issues in fulltext screenings

### DIFF
--- a/colandr/api/v1/routes/fulltext_screenings.py
+++ b/colandr/api/v1/routes/fulltext_screenings.py
@@ -9,8 +9,7 @@ from flask.views import MethodView
 
 from .... import models, tasks
 from ....extensions import db
-from ....utils import assign_status
-from .. import errors, schemas
+from .. import authz, errors, schemas
 
 
 bp = af.APIBlueprint("fulltext_screenings", __name__, url_prefix="/fulltexts")
@@ -37,15 +36,7 @@ class FulltextScreeningAPI(MethodView):
         if not study:
             raise errors.NotFoundError(message=f"<Study(id={id})> not found")
 
-        if (
-            current_user.is_admin is False
-            and db.session.execute(
-                current_user.review_user_assoc.select().filter_by(
-                    review_id=study.review_id
-                )
-            ).one_or_none()
-            is None
-        ):
+        if not authz.user_is_allowed_for_review(current_user, study.review_id):
             raise errors.ForbiddenError(
                 message=f"{current_user} forbidden to get fulltext screenings for this review"
             )
@@ -92,15 +83,9 @@ class FulltextScreeningAPI(MethodView):
         if not study:
             raise errors.NotFoundError(message=f"<Fulltext(id={id})> not found")
 
-        if (
-            current_user.is_admin is False
-            and db.session.execute(
-                current_user.review_user_assoc.select().filter_by(
-                    review_id=study.review_id
-                )
-            ).one_or_none()
-            is None
-        ) or study.review.status == "frozen":
+        if not authz.user_is_allowed_for_review(
+            current_user, study.review_id, if_frozen=False
+        ):
             raise errors.ForbiddenError(
                 message=f"{current_user} forbidden to screen fulltexts for this review"
             )
@@ -212,6 +197,7 @@ class FulltextScreeningAPI(MethodView):
             403: "current app user forbidden to delete fulltext screening; has not screened fulltext, so nothing to delete",
             404: "no fulltext matching id was found",
         },
+        security="TokenAuth",
     )
     @bp.output({}, 204)
     @jwtext.jwt_required(fresh=True)
@@ -222,14 +208,9 @@ class FulltextScreeningAPI(MethodView):
         if not study:
             raise errors.NotFoundError(message=f"<Study(id={id})> not found")
 
-        if (
-            db.session.execute(
-                current_user.review_user_assoc.select().filter_by(
-                    review_id=study.review_id
-                )
-            ).one_or_none()
-            is None
-        ) or study.review.status == "frozen":
+        if not authz.user_is_allowed_for_review(
+            current_user, study.review_id, if_frozen=False
+        ):
             raise errors.ForbiddenError(
                 message=f"{current_user} forbidden to delete fulltext screening for this review"
             )


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- uses standard `authz` functions in fulltext screenings API endpoint
- fixes a bug where token security wasn't specified on POST api/fulltext/id/screenings

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://app.asana.com/1/6325821815997/project/1206730431337718/task/1213422324649118?focus=true

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization checks on fulltext screening read/write/delete paths, which can impact access control behavior (including frozen-review enforcement). Scope is small and reuses the existing centralized `authz.user_is_allowed_for_review` helper.
> 
> **Overview**
> Fulltext screening endpoints now use the shared `authz.user_is_allowed_for_review` helper instead of inline role/team membership queries, aligning access control behavior (and frozen-review blocking on `POST`/`DELETE`) with other v1 routes.
> 
> Also adds missing `security="TokenAuth"` metadata to the `DELETE /fulltexts/<id>/screenings` API docs so the generated OpenAPI spec reflects the JWT requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22a499d0425dafb2750493a908b1b8a9a9971ab1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->