### PR TITLE
fix: error on empty iterable when writing stream

### DIFF
--- a/colandr/lib/fileio/tabular.py
+++ b/colandr/lib/fileio/tabular.py
@@ -1,8 +1,12 @@
 import csv
 import io
 import itertools
+import logging
 import typing as t
 from collections.abc import Iterable, Sequence
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def read(data: str, *, dialect: str = "excel", **kwargs) -> Iterable[list[str]]:
@@ -35,9 +39,16 @@ def write_stream(
     Reference:
         https://stackoverflow.com/questions/32608265/streaming-a-generated-csv-with-flask
     """
-    iter_rows = iter(rows)
-    first_row = next(iter_rows)
-    rows_ = itertools.chain((first_row,), iter_rows)
+    try:
+        iter_rows = iter(rows)
+        first_row = next(iter_rows)
+        rows_ = itertools.chain((first_row,), iter_rows)
+    except StopIteration:
+        LOGGER.warning("no rows available to be written as a stream")
+        writer = csv.writer(DummyWriter(), dialect, **kwargs)
+        yield writer.writerow(cols)
+        return
+
     if isinstance(first_row, dict):
         writer = csv.DictWriter(DummyWriter(), cols, dialect=dialect, **kwargs)
         yield writer.writeheader()


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

catches `StopIteration` when trying to `next()` an empty iterable in `tabular.write_stream()`, and bails out by just writing a header (no rows of actual data)

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

user testing bug report
https://app.asana.com/1/6325821815997/project/1206730431337718/task/1213360108705717?focus=true

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
