### PR TITLE
add hack alembic bigserial migration

### DIFF
--- a/migrations/versions/9c67b9d5e01e_fix_borked_bigserial_cols_if_needed.py
+++ b/migrations/versions/9c67b9d5e01e_fix_borked_bigserial_cols_if_needed.py
@@ -1,0 +1,83 @@
+"""fix-borked-bigserial-cols-if-needed
+
+Revision ID: 9c67b9d5e01e
+Revises: 3143eb18a369
+Create Date: 2026-03-11 13:07:30.838743
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "9c67b9d5e01e"
+down_revision = "3143eb18a369"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # data_extractions pkey: int8 => bigserial (?)
+    column_default = conn.execute(
+        sa.text(
+            "SELECT column_default FROM information_schema.columns "
+            "WHERE table_name = 'data_extractions' AND column_name = 'id'"
+        )
+    ).scalar()
+    # column_default is null or missing "nextval" if it's plain int8 w/o a sequence default
+    if column_default is None or "nextval" not in column_default:
+        conn.execute(
+            sa.text(
+                "CREATE SEQUENCE IF NOT EXISTS data_extractions_id_seq "
+                "AS bigint OWNED BY data_extractions.id"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "SELECT setval('data_extractions_id_seq', "
+                "(SELECT COALESCE(MAX(id), 1) FROM data_extractions))"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "ALTER TABLE data_extractions "
+                "ALTER COLUMN id SET DEFAULT nextval('data_extractions_id_seq')"
+            )
+        )
+
+    # dedupes pkey: int8 => bigserial (?)
+    column_default = conn.execute(
+        sa.text(
+            "SELECT column_default FROM information_schema.columns "
+            "WHERE table_name = 'dedupes' AND column_name = 'id'"
+        )
+    ).scalar()
+    # column_default is null or missing "nextval" if it's plain int8 w/o a sequence default
+    if column_default is None or "nextval" not in column_default:
+        conn.execute(
+            sa.text(
+                "CREATE SEQUENCE IF NOT EXISTS dedupes_id_seq "
+                "AS bigint OWNED BY dedupes.id"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "SELECT setval('dedupes_id_seq', "
+                "(SELECT COALESCE(MAX(id), 1) FROM dedupes))"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "ALTER TABLE dedupes "
+                "ALTER COLUMN id SET DEFAULT nextval('dedupes_id_seq')"
+            )
+        )
+
+
+def downgrade():
+    # restoring a plain int8 is probably not desirable;
+    # leave downgrade as a no-op or implement as needed
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11"
 dependencies = [
-  "alembic~=1.17.0",
+  "alembic~=1.18.0",
   "apiflask~=3.0.0",
   "arrow~=1.3.0",
   "bibtexparser~=1.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -133,16 +133,16 @@ wheels = [
 
 [[package]]
 name = "alembic"
-version = "1.17.0"
+version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/45/6f4555f2039f364c3ce31399529dcf48dd60726ff3715ad67f547d87dfd2/alembic-1.17.0.tar.gz", hash = "sha256:4652a0b3e19616b57d652b82bfa5e38bf5dbea0813eed971612671cb9e90c0fe", size = 1975526, upload-time = "2025-10-11T18:40:13.585Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/1f/38e29b06bfed7818ebba1f84904afdc8153ef7b6c7e0d8f3bc6643f5989c/alembic-1.17.0-py3-none-any.whl", hash = "sha256:80523bc437d41b35c5db7e525ad9d908f79de65c27d6a5a5eab6df348a352d99", size = 247449, upload-time = "2025-10-11T18:40:16.288Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "alembic", specifier = "~=1.17.0" },
+    { name = "alembic", specifier = "~=1.18.0" },
     { name = "apiflask", specifier = "~=3.0.0" },
     { name = "arrow", specifier = "~=1.3.0" },
     { name = "bibtexparser", specifier = "~=1.4.0" },


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds an alembic migration that converts `data_extractions.id` and `dedupes.id` pkey columns from `int8` to `bigserial` if and only if those columns aren't _already_ `bigserial`
- bumps `alembic` to latest version

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

afaict this is the direct cause of the error in this ticket: https://app.asana.com/1/6325821815997/project/1206730431337718/task/1213422324649118?focus=true

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
