### PR TITLE
ensure boolean search queries correctly generate

### DIFF
--- a/colandr/api/v1/schemas.py
+++ b/colandr/api/v1/schemas.py
@@ -86,6 +86,13 @@ class ReviewPlanPICO(af.Schema):
     comparison = af.fields.String(validate=af.validators.Length(max=300))
     outcome = af.fields.String(validate=af.validators.Length(max=300))
 
+    @ma.pre_load
+    def coerce_synonyms_to_list(self, data: dict, **kwargs) -> dict:
+        synonyms = data.get("synonyms")
+        if isinstance(synonyms, str):
+            data["synonyms"] = [s.strip() for s in synonyms.split(",") if s.strip()]
+        return data
+
 
 class ReviewPlanKeyterm(af.Schema):
     group = af.fields.String(required=True, validate=af.validators.Length(max=100))

--- a/colandr/utils.py
+++ b/colandr/utils.py
@@ -46,7 +46,10 @@ def get_boolean_search_query(keyterms: Iterable[dict]) -> str:
 
 
 def _boolify_term_set(term_set: dict) -> str:
-    if term_set.get("synonyms"):
+    synonyms = term_set.get("synonyms")
+    if isinstance(synonyms, str):  # corrupted data guard
+        synonyms = [s.strip() for s in synonyms.split(",") if s.strip()]
+    if synonyms:
         return (
             "("
             + " OR ".join(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,14 @@ from colandr import utils
             ],
             '"foo"\nAND\n("spam" OR "eggs")',
         ),
+        (
+            [
+                {"term": "foo", "group": "test1"},
+                {"term": "bar", "group": "test1", "synonyms": ["bat", "baz"]},
+                {"term": "spam", "group": "test2", "synonyms": ["eggs"]},
+            ],
+            '("foo" OR ("bar" OR "bat" OR "baz"))\nAND\n("spam" OR "eggs")',
+        ),
     ],
 )
 def test_get_boolean_search_query(keyterms, exp_result):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+import pytest
+
+from colandr import utils
+
+
+@pytest.mark.parametrize(
+    ["keyterms", "exp_result"],
+    [
+        (
+            [{"term": "foo", "group": "test", "synonyms": ["bar", "bat"]}],
+            '("foo" OR "bar" OR "bat")',
+        ),
+        (
+            [
+                {"term": "foo", "group": "test1"},
+                {"term": "spam", "group": "test2", "synonyms": ["eggs"]},
+            ],
+            '"foo"\nAND\n("spam" OR "eggs")',
+        ),
+    ],
+)
+def test_get_boolean_search_query(keyterms, exp_result):
+    result = utils.get_boolean_search_query(keyterms)
+    assert result == exp_result


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds unit tests for `get_boolean_search_query()` utils function
- adds schema- and func-level guards against synonyms that come through as a comma-delimited string rather than a list of strings

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://app.asana.com/1/6325821815997/project/1206730431337718/task/1212806079039658?focus=true

it doesn't seem like this is an actual bug in the code; is it _possible_ that sam was testing on old data?

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
