### PR TITLE
hotfix: hack fixes for deduper data loading

### DIFF
--- a/colandr/api/v1/routes/dedupe.py
+++ b/colandr/api/v1/routes/dedupe.py
@@ -56,6 +56,8 @@ class DedupeAPI(MethodView):
 
 # NOTE: flask-limiter doesn't behave when applied to routes via MethodView.decorators
 # this is an ugly but serviceable work-around
-dedupe_api_view_func = DedupeAPI.as_view("dedupe")
-dedupe_api_view_func = limiter.limit("1 per 5 seconds")(dedupe_api_view_func)
-bp.add_url_rule("/", view_func=dedupe_api_view_func)
+# dedupe_api_view_func = DedupeAPI.as_view("dedupe")
+# dedupe_api_view_func = limiter.limit("1 per 5 seconds")(dedupe_api_view_func)
+# bp.add_url_rule("/", view_func=dedupe_api_view_func)
+# HACK: let's not rate-limit it, and instead kick the can down the road
+bp.add_url_rule("/", view_func=DedupeAPI.as_view("dedupe"))

--- a/colandr/config.py
+++ b/colandr/config.py
@@ -92,10 +92,9 @@ FULLTEXT_UPLOADS_DIR = os.path.join(FILESYSTEM_ROOT_DIR, "fulltexts")
 ALLOWED_CITATION_UPLOAD_EXTENSIONS = {".ris", ".txt", ".bib", ".csv", ".tsv"}
 ALLOWED_FULLTEXT_UPLOAD_EXTENSIONS = {".txt", ".pdf"}
 
+# (internal) data only
 COLANDR_APP_DIR = os.environ.get("COLANDR_APP_DIR", "/app")
-DEDUPE_MODELS_DIR = os.path.join(
-    COLANDR_APP_DIR, "colandr_data", "dedupe-v2", "model_202407"
-)
+DEDUPE_MODELS_DIR = os.path.join(COLANDR_APP_DIR, "colandr_data", "dedupe-v2")
 
 # metadata extraction config
 METADATA_THRESHOLD = float(os.environ.get("COLANDR_METADATA_THRESHOLD", "0.65"))

--- a/colandr/tasks.py
+++ b/colandr/tasks.py
@@ -134,10 +134,7 @@ def deduplicate_citations(review_id: int):
     results = (dict(row) for row in db.session.execute(stmt).mappings())
 
     settings_fpath = os.path.join(
-        current_app.config["COLANDR_APP_DIR"],
-        "colandr_data",
-        "dedupe-v2",
-        "dedupe-splink-model.json",
+        current_app.config["DEDUPE_MODELS_DIR"], "dedupe-splink-model.json"
     )
     deduper = DeduperV2.from_records(
         results, id_col="record_id", settings=settings_fpath


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- removes (disabled) rate-limiter from `dedupe/` api endpoint
- more clearly specifies deduper model settings loading from internal app data

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://app.asana.com/1/6325821815997/project/1206730431337718/task/1214036391716477?focus=true

there's a difference between prod and dev setups wrt data, and the current setup isn't very clear. hence, bugs.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
