### PR TITLE
hotfix: skip invalid records for ranker learn

### DIFF
--- a/colandr/lib/models/study_ranker.py
+++ b/colandr/lib/models/study_ranker.py
@@ -114,6 +114,11 @@ class StudyRanker:
     def learn_one(self, record: dict[str, t.Any]) -> None:
         x = record[self.text_col]
         y = record[self.target_col]
+        if not x:
+            LOGGER.warning(
+                "StudyRanker.learn_one() can't learn from empty record text; skipping ..."
+            )
+            return
         self.model.learn_one(x, y)
 
     def predict_one(


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

trying to mitigate unexpected timeouts in job queue

```
[2026-04-11 21:26:36,014: INFO/ForkPoolWorker-1] <Review(id=4911)>: new study ranker model cloned ...
[2026-04-11 21:28:37,107: ERROR/ForkPoolWorker-1] Task colandr.tasks.train_study_ranker_model[dbeac2f0-b290-4bf3-b0e6-171015ec52d9] raised unexpected: TypeError("descriptor 'lower' for 'str' objects doesn't apply to a 'NoneType' object")
Traceback (most recent call last):
  File "/app/.venv/lib/python3.12/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/app/colandr/extensions.py", line 57, in __call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/colandr/tasks.py", line 405, in train_study_ranker_model
    _train_study_ranker_model_from_scratch(study_ranker, review_id)
  File "/app/colandr/tasks.py", line 482, in _train_study_ranker_model_from_scratch
    study_ranker.learn_one(record)
  File "/app/colandr/lib/models/study_ranker.py", line 117, in learn_one
    self.model.learn_one(x, y)
  File "/app/.venv/lib/python3.12/site-packages/river/compose/pipeline.py", line 456, in learn_one
    step.learn_one(x)
  File "/app/.venv/lib/python3.12/site-packages/river/feature_extraction/vectorize.py", line 475, in learn_one
    terms = self.process_text(x)
            ^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/river/feature_extraction/vectorize.py", line 220, in process_text
    x = step(x)
        ^^^^^^^
TypeError: descriptor 'lower' for 'str' objects doesn't apply to a 'NoneType' object
```

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
