### PR TITLE
fix edge-case logic in screening endpoints

### DIFF
--- a/colandr/api/v1/routes/citation_screenings.py
+++ b/colandr/api/v1/routes/citation_screenings.py
@@ -106,9 +106,7 @@ class CitationScreeningAPI(MethodView):
             user_id = current_user.id
 
         if db.session.execute(
-            study.screenings.select().filter_by(
-                stage="citation", user_id=current_user.id
-            )
+            study.screenings.select().filter_by(stage="citation", user_id=user_id)
         ).one_or_none():
             raise errors.ForbiddenError(
                 message=f"{current_user} has already screened {study}"

--- a/colandr/api/v1/routes/fulltext_screenings.py
+++ b/colandr/api/v1/routes/fulltext_screenings.py
@@ -112,9 +112,7 @@ class FulltextScreeningAPI(MethodView):
             user_id = current_user.id
 
         if db.session.execute(
-            study.screenings.select().filter_by(
-                stage="fulltext", user_id=current_user.id
-            )
+            study.screenings.select().filter_by(stage="fulltext", user_id=user_id)
         ).one_or_none():
             raise errors.ForbiddenError(
                 message=f"{current_user} has already screened {study}"

--- a/colandr/models.py
+++ b/colandr/models.py
@@ -832,20 +832,16 @@ def update_study_num_reviewers(mapper, connection: sa.Connection, target):
 def update_study_status(mapper, connection: sa.Connection, target):
     review_id = target.review_id
     study_id = target.study_id
-    study = target.study
-    # TODO(burton): you added this so that conftest populate_db func would work
-    # for reasons unknown, the target here didn't have a loaded citation object
-    # but this is _probably_ a bad thing, and you should find a way to fix it
-    if study is None:
-        study = connection.execute(
-            sa.select(
-                Study.num_citation_reviewers,
-                Study.num_fulltext_reviewers,
-            ).filter_by(id=study_id)
-        ).one_or_none()
-    assert study is not None  # type guard
-    # prep stage-specific variables
     stage = target.stage
+    # query the Study directly -- never rely on target.study
+    # one *must* exist, given fkey constraint
+    study = connection.execute(
+        sa.select(
+            Study.num_citation_reviewers,
+            Study.num_fulltext_reviewers,
+        ).filter_by(id=study_id)
+    ).one()
+    # prep stage-specific variables
     if stage == "citation":
         num_reviewers = study.num_citation_reviewers
         study_status_col_str = "citation_status"


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- fixes screening duplication checks in cases where an admin submits a screening on behalf of another user -- super niche, but i noticed this as a legit bug
- standardizes event listener logic to always get a fresh study record after screening submission; this is super nit-picky, but could theoretically have caused inconsistency on screening submission in the past (i doubt it though)

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://app.asana.com/1/6325821815997/project/1206730431337718/task/1214036395387356?focus=true

i'm not sure the mystery behavior in that ticket is even real and/or if these changes fix it, but still worth addressing while i was digging deep

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

like PR #220, this is also meant as a production fix; should we merge it into the main branch of develop?