### PR TITLE
fix(nginx): circular redirects behind ALB-terminated TLS

### DIFF
--- a/deployment/nginx/colandr.conf
+++ b/deployment/nginx/colandr.conf
@@ -8,11 +8,24 @@
 #   git pull
 #   sudo nginx -t && sudo systemctl reload nginx
 #
-# TLS:
-#   See docs/production-deployment.md for certbot instructions.
+
+map $http_x_forwarded_proto $colandr_effective_scheme {
+    https   https;
+    default $scheme;
+}
+
+map $http_x_forwarded_proto $colandr_pass_x_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}
 
 upstream colandr_api {
     server 127.0.0.1:5000;
+    keepalive 32;
+}
+
+upstream colandr_api_develop {
+    server 127.0.0.1:5001;
     keepalive 32;
 }
 
@@ -26,22 +39,6 @@ server {
     }
 
     location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name api.colandrapp.com;
-
-    ssl_certificate /etc/letsencrypt/live/api.colandrapp.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/api.colandrapp.com/privkey.pem;
-    include /etc/letsencrypt/options-ssl-nginx.conf;
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-
-    client_max_body_size 50M;
-
-    location / {
         proxy_pass http://colandr_api;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
@@ -49,7 +46,31 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $colandr_pass_x_forwarded_proto;
         proxy_set_header X-Forwarded-Host $host;
+        client_max_body_size 50M;
+    }
+}
+
+server {
+    listen 80;
+    server_name dev-api.colandrapp.com;
+
+    # Let's Encrypt validation
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        proxy_pass http://colandr_api_develop;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $colandr_pass_x_forwarded_proto;
+        proxy_set_header X-Forwarded-Host $host;
+        client_max_body_size 50M;
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colandr"
-version = "1.1.0"
+version = "1.1.1"
 description = "Back-end code for running the colandr app."
 readme = { file = "README.md", content-type = "text/markdown" }
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -444,7 +444,7 @@ wheels = [
 
 [[package]]
 name = "colandr"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
- **Prod API (`api.colandrapp.com`):** Serve on **port 80** with **`proxy_pass`** to `127.0.0.1:5000` instead of **`return 301` → `https://…`** on `/`. That redirect was the root cause of **redirect loops** once TLS moved to the ALB (client → HTTPS on ALB → HTTP to nginx → “upgrade” to HTTPS again).
- **Drop nginx :443** for this hostname so the config matches **HTTP-only targets** behind the load balancer.
- **Forward `X-Forwarded-Proto`** from the ALB (with a small `map` when the header is empty) so Flask / ProxyFix still see **https** for real browser traffic.
- **`dev-api.colandrapp.com`:** Second **:80** `server` → `127.0.0.1:5001`, same header pattern.

## context

After **TLS termination on the ALB**, nginx only sees **HTTP** on **80**. Forcing **`https://`** in nginx recreated HTTPS at a layer that the ALB already handled, resulting in **circular redirects** for users.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214744489260377